### PR TITLE
feat: add uptime demo app config

### DIFF
--- a/uptime-monitor/DOCS.md
+++ b/uptime-monitor/DOCS.md
@@ -1,0 +1,252 @@
+# Nuon App Configuration
+
+This directory contains the Nuon configuration for the Uptime Monitor application. It defines how the app is packaged, deployed, and managed across customer installs.
+
+## Documentation
+
+- [Nuon Documentation](https://docs.nuon.co)
+- [Configuration Files Reference](https://docs.nuon.co/configuration-files)
+- [Example App Configs](https://github.com/nuonco/example-app-configs)
+
+## Directory Structure
+
+```
+.
+├── metadata.toml          # App metadata (name, description, readme)
+├── sandbox.toml           # Base infrastructure (EKS cluster, VPC, DNS)
+├── sandbox.tfvars         # Additional Terraform variables for sandbox
+├── stack.toml             # CloudFormation stack for install bootstrapping
+├── runner.toml            # Nuon runner configuration
+├── inputs.toml            # User-configurable inputs
+├── break_glass.toml       # Emergency access roles
+│
+├── components/            # Deployable units (images, Helm, K8s, Terraform)
+│   ├── 0-api-image.toml   # Docker build: API image
+│   ├── 0-ui-image.toml    # Docker build: UI image
+│   ├── 1-s3.toml          # Terraform: S3 bucket
+│   ├── 1-rds.toml         # Terraform: PostgreSQL RDS
+│   ├── 1-irsa.toml        # Terraform: IAM role for service accounts
+│   ├── 2-api.toml         # K8s manifest: API deployment
+│   ├── 2-ui.toml          # K8s manifest: UI deployment
+│   ├── 3-headlamp.toml    # Helm chart: Kubernetes dashboard
+│   └── 4-alb.toml         # K8s manifest: Application Load Balancer
+│
+├── actions/               # Bash scripts for install operations
+│   ├── rds_creds.toml     # Copy RDS credentials to K8s secret
+│   ├── headlamp_token.toml # Generate Headlamp auth token
+│   └── flush_healthchecks.toml # Cron job to clean old data
+│
+├── permissions/           # IAM roles for install lifecycle
+│   ├── provision.toml     # Role for provisioning
+│   ├── maintenance.toml   # Role for day-2 operations
+│   ├── deprovision.toml   # Role for teardown
+│   └── *_boundary.json    # Permission boundary policies
+│
+└── secrets/               # Secret definitions (if any)
+```
+
+## Configuration Overview
+
+### Core Configuration Files
+
+| File               | Purpose                                                     |
+|--------------------|-------------------------------------------------------------|
+| `metadata.toml`    | App display name, description, and README for the dashboard |
+| `sandbox.toml`     | EKS cluster, VPC, DNS - the base infrastructure layer       |
+| `stack.toml`       | CloudFormation template for bootstrapping installs          |
+| `runner.toml`      | Nuon runner that executes deployments in customer accounts  |
+| `inputs.toml`      | Customer-configurable values (e.g., healthcheck interval)   |
+| `break_glass.toml` | Emergency access roles for incident response                |
+
+### Components
+
+Components are the deployable units of your app. See [components/README.md](components/README.md) for details.
+
+**Supported types:**
+- `docker_build` - Build images from Dockerfiles
+- `container_image` - Reference pre-built images
+- `helm_chart` - Deploy Helm charts
+- `kubernetes_manifest` - Deploy raw K8s YAML
+- `terraform_module` - Provision cloud infrastructure
+
+### Actions
+
+Actions are bash scripts triggered manually, on schedules, or by lifecycle events. See [actions/README.md](actions/README.md) for details.
+
+### Permissions
+
+IAM roles used during install lifecycle phases:
+- **Provision**: Creates infrastructure during initial install
+- **Maintenance**: Day-2 operations (deployments, updates)
+- **Deprovision**: Tears down infrastructure on uninstall
+
+## Template Variables
+
+Nuon uses Go templating throughout configuration files. Common variables:
+
+```
+# Install information
+{{.nuon.install.id}}                    # Unique install identifier
+{{.nuon.install.name}}                  # Install name
+{{.nuon.app.name}}                      # App name
+
+# User inputs (from inputs.toml)
+{{.nuon.install.inputs.INPUT_NAME}}
+
+# CloudFormation stack outputs
+{{.nuon.install_stack.outputs.region}}
+{{.nuon.install_stack.outputs.vpc_id}}
+
+# Sandbox outputs
+{{.nuon.install.sandbox.outputs.vpc.id}}
+{{.nuon.install.sandbox.outputs.cluster.oidc_provider}}
+{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}
+
+# Component outputs
+{{.nuon.components.COMPONENT.outputs.OUTPUT_NAME}}
+
+# Docker image outputs
+{{.nuon.components.IMAGE.outputs.image.repository}}
+{{.nuon.components.IMAGE.outputs.image.tag}}
+```
+
+## Syncing Configuration
+
+After making changes, sync to Nuon:
+
+```bash
+cd uptime-monitor
+nuon apps sync
+```
+
+This validates syntax, uploads configuration, and triggers builds for changed components.
+
+## Schema Validation
+
+Each config file supports JSON schema validation. Add this line at the top of your file for editor support:
+
+```toml
+#:schema https://api.nuon.co/v1/general/config-schema?type=TYPE
+```
+
+Valid types: `metadata`, `sandbox`, `stack`, `runner`, `input`, `input-group`, `action`, `helm`, `terraform`, `docker-build`, `kubernetes-manifest`, `container-image`, `break-glass`
+
+---
+
+# README Interpolation
+
+This README file (referenced in `metadata.toml`) is rendered per-install in the Nuon dashboard. It supports Go templating with access to the full install state via the `.nuon` object.
+
+## How It Works
+
+When viewing an install in the dashboard, Nuon renders this README server-side, replacing template variables with actual values from that specific install. This allows you to show install-specific information like URLs, tokens, and status.
+
+## The `.nuon` Object
+
+The `.nuon` object contains the complete install state. Key attributes:
+
+### App Information
+```
+{{.nuon.app.name}}                      # App name from metadata.toml
+{{.nuon.app.id}}                        # App ID
+```
+
+### Install Information
+```
+{{.nuon.install.id}}                    # Unique install identifier
+{{.nuon.install.name}}                  # Install name
+{{.nuon.install.inputs.INPUT_NAME}}     # User-provided input values
+```
+
+### Sandbox Information
+```
+{{.nuon.sandbox.type}}                  # Sandbox type (e.g., "aws-eks")
+{{.nuon.install.sandbox.outputs.X}}     # Any Terraform output from sandbox
+```
+
+Common sandbox outputs (aws-eks-sandbox):
+```
+{{.nuon.install.sandbox.outputs.vpc.id}}
+{{.nuon.install.sandbox.outputs.vpc.private_subnet_ids}}
+{{.nuon.install.sandbox.outputs.cluster.cluster_name}}
+{{.nuon.install.sandbox.outputs.cluster.oidc_provider}}
+{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}
+{{.nuon.install.sandbox.outputs.nuon_dns.internal_domain.name}}
+{{.nuon.install.sandbox.outputs.account.aws_region}}
+```
+
+### Install Stack (CloudFormation) Outputs
+```
+{{.nuon.install_stack.outputs.region}}
+{{.nuon.install_stack.outputs.vpc_id}}
+```
+
+### Component Information
+```
+{{.nuon.components.populated}}          # Boolean: are components deployed?
+{{.nuon.components.components}}         # Map of all components
+
+# Iterate over components:
+{{range $name, $component := .nuon.components.components}}
+  {{$name}}: {{$component.status}}
+{{end}}
+
+# Access specific component outputs:
+{{.nuon.components.COMPONENT_NAME.outputs.OUTPUT_NAME}}
+{{.nuon.components.s3.outputs.bucket_name}}
+{{.nuon.components.rds.outputs.db_host}}
+```
+
+### Action Workflow Outputs
+```
+# Access output from a completed action step:
+{{.nuon.actions.workflows.ACTION_NAME.outputs.steps.STEP_NAME.OUTPUT_KEY}}
+
+# Example: Get token from headlamp_token action's "create" step:
+{{.nuon.actions.workflows.headlamp_token.outputs.steps.create.token}}
+```
+
+### Secrets
+```
+{{.nuon.secrets.SECRET_NAME}}           # Synced secret values
+```
+
+## Go Template Functions
+
+READMEs support full Go templating syntax:
+
+### Conditionals
+```
+{{ if .nuon.components.populated }}
+  Components are deployed!
+{{ else }}
+  No components yet.
+{{ end }}
+```
+
+### Loops
+```
+| Component | Status |
+|-----------|--------|
+{{- range $name, $component := .nuon.components.components }}
+| {{ $name }} | {{ $component.status }} |
+{{- end }}
+```
+
+### JSON Output
+```
+{{ toPrettyJson .nuon }}                # Pretty-print entire state as JSON
+```
+
+## Debugging
+
+To inspect the full `.nuon` object structure, add this to your README:
+
+```markdown
+<details>
+  <summary>Full Install State</summary>
+  <pre>{{ toPrettyJson .nuon }}</pre>
+</details>
+```
+
+This renders a collapsible section showing all available data for the install.

--- a/uptime-monitor/README.md
+++ b/uptime-monitor/README.md
@@ -1,0 +1,62 @@
+# Uptime Monitor
+
+**Warning:** This application is for demonstration purposes only and is not intended for production use. The admin panel allows triggering AWS infrastructure changes directly from the application.
+
+A demo application that monitors website uptime. Enter a URL and the system periodically checks if it's up, storing results in PostgreSQL and displaying them as a real-time bar graph.
+
+**Your Instance:** [{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}](http://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}})
+
+## Headlamp Dashboard
+
+Access the Kubernetes dashboard to view pods, deployments, and cluster resources.
+
+**Headlamp:** [{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/headlamp](http://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/headlamp/)
+
+**Authentication Token:**
+```
+{{ .nuon.actions.workflows.headlamp_token.outputs.steps.create.token }}
+```
+
+## Creating Drift
+
+This demo app is configured to detect drift across Terraform, Kubernetes, and Helm components. You can intentionally create drift to see how Nuon detects and displays it in the dashboard.
+
+### Terraform Drift (RDS)
+
+The app includes an admin panel that modifies RDS settings outside of Terraform.
+
+1. Go to [{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/admin](http://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/admin)
+2. Click the button to modify the RDS instance (changes max allocated storage and tags)
+3. In the Nuon dashboard, trigger a drift scan on the `rds` component
+4. Nuon will detect the configuration has drifted from the Terraform state
+
+### Kubernetes Manifest Drift (API/UI)
+
+Modify deployments directly in Kubernetes to create drift from the declared manifests.
+
+1. Open [Headlamp](http://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/headlamp/) and login with the token above
+2. Navigate to **Workloads > Deployments**
+3. Select the `api` or `ui` deployment
+4. Click **Edit** and change the replica count (e.g., from 1 to 2)
+5. Save the changes
+6. In the Nuon dashboard, trigger a drift scan on the `api` or `ui` component
+7. Nuon will detect the replica count differs from the manifest
+
+### Helm Drift (Headlamp)
+
+Modify Helm-managed resources to create drift from the chart values.
+
+1. Open [Headlamp](http://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/headlamp/) and login with the token above
+2. Navigate to **Workloads > Deployments**
+3. Select the `headlamp` deployment
+4. Click **Edit** and modify a value (e.g., change replica count or resource limits)
+5. Save the changes
+6. In the Nuon dashboard, trigger a drift scan on the `headlamp` component
+7. Nuon will detect the deployed resources differ from the Helm release
+
+## Full State
+
+<details>
+  <summary>Full Install State</summary>
+  <pre>{{ toPrettyJson .nuon }}</pre>
+</details>

--- a/uptime-monitor/actions/README.md
+++ b/uptime-monitor/actions/README.md
@@ -1,0 +1,102 @@
+# Actions
+
+Actions are bash scripts that run in the context of an install. They can be triggered manually, on a schedule, or by lifecycle events (e.g., after a component deploys).
+
+## Trigger Types
+
+| Trigger                 | Description                    | Example Use Case                     |
+|-------------------------|--------------------------------|--------------------------------------|
+| `manual`                | Run from dashboard or CLI      | Debugging, one-off tasks             |
+| `cron`                  | Run on a schedule              | Cleanup jobs, health checks          |
+| `post-deploy-component` | Run after a component deploys  | Initialize databases, create secrets |
+| `pre-deploy-component`  | Run before a component deploys | Validate prerequisites               |
+| `post-provision`        | Run after install provisioning | Initial setup tasks                  |
+| `post-update-inputs`    | Run after inputs are updated   | Apply configuration changes          |
+
+## Actions in This App
+
+| Action                    | Triggers                                 | Description                                                            |
+|---------------------------|------------------------------------------|------------------------------------------------------------------------|
+| `rds_creds.toml`          | post-deploy-component (rds), manual      | Copies RDS credentials from AWS Secrets Manager to a Kubernetes secret |
+| `headlamp_token.toml`     | post-deploy-component (headlamp), manual | Generates a Kubernetes token for Headlamp dashboard access             |
+| `flush_healthchecks.toml` | cron (hourly), manual                    | Deletes healthcheck records older than 24 hours                        |
+
+## Writing Action Scripts
+
+### Inline Scripts
+
+```toml
+[[steps]]
+name = "my-step"
+inline_contents = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "Hello from $INSTALL_ID"
+"""
+
+[steps.env_vars]
+INSTALL_ID = "{{ .nuon.install.id }}"
+```
+
+### Scripts from Repository
+
+```toml
+[[steps]]
+name = "my-step"
+command = "./scripts/my-script.sh"
+
+[steps.public_repo]
+repo      = "nuonco/uptime-monitor"
+directory = "scripts"
+branch    = "main"
+```
+
+## Environment Variables
+
+Actions have access to:
+
+- **Custom env_vars**: Defined in the action config with Nuon template variables
+- **`$NUON_ACTIONS_OUTPUT_FILEPATH`**: Write JSON here to return structured output to the dashboard
+
+### Template Variables in env_vars
+
+```toml
+[steps.env_vars]
+# Component outputs
+BUCKET_NAME = "{{ .nuon.components.s3.outputs.bucket_name }}"
+DB_HOST     = "{{ .nuon.components.rds.outputs.db_host }}"
+
+# Install info
+INSTALL_ID = "{{ .nuon.install.id }}"
+REGION     = "{{ .nuon.install_stack.outputs.region }}"
+
+# User inputs
+INTERVAL = "{{ .nuon.install.inputs.healthcheck_interval_seconds }}"
+```
+
+## Returning Output
+
+Actions can return structured data to the Nuon dashboard:
+
+```bash
+#!/usr/bin/env bash
+TOKEN=$(kubectl create token my-service-account)
+printf '{"token": "%s"}' "$TOKEN" >> $NUON_ACTIONS_OUTPUT_FILEPATH
+```
+
+The output appears in the dashboard after the action completes.
+
+## Break Glass Roles
+
+For actions requiring elevated permissions, specify a break glass role:
+
+```toml
+name = "emergency-repair"
+break_glass_role = "sandbox-break-glass"
+```
+
+## Documentation
+
+- [Actions Overview](https://docs.nuon.co/concepts/actions)
+- [Configuring Actions](https://docs.nuon.co/guides/actions)
+- [Break Glass](https://docs.nuon.co/production-readiness/break-glass)

--- a/uptime-monitor/actions/flush_healthchecks.toml
+++ b/uptime-monitor/actions/flush_healthchecks.toml
@@ -1,0 +1,96 @@
+# =============================================================================
+# NUON ACTION - Flush Healthchecks
+# =============================================================================
+#
+# Deletes healthcheck records older than 24 hours from the database.
+# Runs hourly on a cron schedule to prevent unbounded data growth.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=action
+#
+# -----------------------------------------------------------------------------
+# CRON TRIGGERS
+# -----------------------------------------------------------------------------
+#
+# Actions can run on a schedule using standard cron syntax:
+#   "* * * * *"     = every minute
+#   "0 * * * *"     = every hour (at minute 0)
+#   "0 0 * * *"     = daily at midnight
+#   "0 0 * * 0"     = weekly on Sunday
+#   "*/5 * * * *"   = every 5 minutes
+#
+# =============================================================================
+
+
+name    = "flush_healthchecks"
+timeout = "5m"
+
+
+# -----------------------------------------------------------------------------
+# TRIGGERS
+# -----------------------------------------------------------------------------
+# Runs every hour, or manually from dashboard.
+
+[[triggers]]
+type          = "cron"
+cron_schedule = "0 * * * *"
+
+[[triggers]]
+type = "manual"
+
+
+# -----------------------------------------------------------------------------
+# STEPS
+# -----------------------------------------------------------------------------
+
+[[steps]]
+name = "flush"
+
+# Creates a temporary postgres pod to run the DELETE query.
+# Reads database credentials from the Kubernetes secret created by rds_creds action.
+inline_contents = """
+#!/usr/bin/env bash
+# Deletes healthcheck records older than 24 hours.
+# Uses a temporary postgres pod to execute SQL against RDS.
+# Database credentials are read from Kubernetes secret (created by rds_creds action).
+set -euo pipefail
+
+echo "[flush-healthchecks] reading db credentials from secret"
+DB_HOST=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.host}' | base64 -d)
+DB_PORT=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.port}' | base64 -d)
+DB_NAME=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.database}' | base64 -d)
+DB_USER=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.username}' | base64 -d)
+DB_PASS=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.password}' | base64 -d)
+
+POD_NAME="flush-healthchecks-$(date +%s)"
+
+echo "[flush-healthchecks] creating temporary postgres client pod"
+kubectl run "$POD_NAME" \
+  --namespace="$NAMESPACE" \
+  --image=postgres:18-alpine \
+  --restart=Never \
+  --env="PGPASSWORD=$DB_PASS" \
+  --env="PGHOST=$DB_HOST" \
+  --env="PGPORT=$DB_PORT" \
+  --env="PGUSER=$DB_USER" \
+  --env="PGDATABASE=$DB_NAME" \
+  --command -- sleep 300
+
+echo "[flush-healthchecks] waiting for pod to be ready"
+kubectl wait --namespace="$NAMESPACE" --for=condition=Ready pod/"$POD_NAME" --timeout=60s
+
+cleanup() {
+  echo "[flush-healthchecks] cleaning up temporary pod"
+  kubectl delete pod "$POD_NAME" --namespace="$NAMESPACE" --ignore-not-found=true
+}
+trap cleanup EXIT
+
+echo "[flush-healthchecks] deleting healthchecks older than 24h"
+kubectl exec -n "$NAMESPACE" "$POD_NAME" -- psql -c \
+  "DELETE FROM healthcheck WHERE created_at < NOW() - INTERVAL '24 hours';"
+
+echo "[flush-healthchecks] done"
+"""
+
+[steps.env_vars]
+SECRET_NAME = "db-credentials"
+NAMESPACE   = "default"

--- a/uptime-monitor/actions/headlamp_token.toml
+++ b/uptime-monitor/actions/headlamp_token.toml
@@ -1,0 +1,59 @@
+# =============================================================================
+# NUON ACTION - Headlamp Token
+# =============================================================================
+#
+# Generates a Kubernetes service account token for Headlamp dashboard access.
+# The token is returned as action output and displayed in the Nuon dashboard.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=action
+#
+# -----------------------------------------------------------------------------
+# ACTION OUTPUT
+# -----------------------------------------------------------------------------
+#
+# Actions can return structured output by writing JSON to $NUON_ACTIONS_OUTPUT_FILEPATH.
+# This output is displayed in the Nuon dashboard after the action completes.
+#
+# =============================================================================
+
+
+name    = "headlamp_token"
+timeout = "1m"
+
+
+# -----------------------------------------------------------------------------
+# TRIGGERS
+# -----------------------------------------------------------------------------
+# Runs after Headlamp deploys, or manually from dashboard.
+
+[[triggers]]
+type           = "post-deploy-component"
+component_name = "headlamp"
+
+[[triggers]]
+type = "manual"
+
+
+# -----------------------------------------------------------------------------
+# STEPS
+# -----------------------------------------------------------------------------
+
+[[steps]]
+name = "create"
+
+# Generates a long-lived token for Headlamp authentication.
+# Writes JSON output to $NUON_ACTIONS_OUTPUT_FILEPATH for display in dashboard.
+inline_contents = """
+#!/usr/bin/env bash
+# Generates a Kubernetes token for Headlamp dashboard authentication.
+# Output is written to $NUON_ACTIONS_OUTPUT_FILEPATH (provided by Nuon runner).
+set -euo pipefail
+
+echo "[headlamp-token] generating token"
+TOKEN=$(kubectl create token headlamp -n "$NAMESPACE" --duration=8760h)
+printf '{"token": "%s"}' "$TOKEN" >> $NUON_ACTIONS_OUTPUT_FILEPATH
+echo "[headlamp-token] done"
+"""
+
+[steps.env_vars]
+NAMESPACE = "default"

--- a/uptime-monitor/actions/rds_creds.toml
+++ b/uptime-monitor/actions/rds_creds.toml
@@ -1,0 +1,122 @@
+# =============================================================================
+# NUON ACTION - RDS Credentials
+# =============================================================================
+#
+# Copies RDS credentials from AWS Secrets Manager to a Kubernetes secret,
+# making them available to pods via environment variables or volume mounts.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=action
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Action identifier
+#   timeout       (required)  Max execution time (Go duration: 30s, 5m, 30m max)
+#   triggers      (required)  When the action runs (manual, cron, lifecycle events)
+#   steps         (required)  Ordered list of steps to execute
+#   dependencies  (optional)  Components that must exist (auto-extracted from templates)
+#   break_glass_role (optional) Elevated permissions for emergency operations
+#
+# -----------------------------------------------------------------------------
+# TRIGGER TYPES
+# -----------------------------------------------------------------------------
+#
+#   manual                     - Run from dashboard or CLI
+#   cron                       - Run on schedule (cron_schedule = "*/5 * * * *")
+#   post-deploy-component      - Run after a component deploys (component_name required)
+#   pre-deploy-component       - Run before a component deploys
+#   post-provision             - Run after install provisioning
+#   post-deploy-all-components - Run after all components deploy
+#   post-update-inputs         - Run after inputs are updated
+#
+# See docs for full list: https://docs.nuon.co/concepts/actions
+#
+# =============================================================================
+
+
+name    = "rds_creds"
+timeout = "1m"
+
+
+# -----------------------------------------------------------------------------
+# TRIGGERS
+# -----------------------------------------------------------------------------
+# This action runs automatically after the RDS component deploys,
+# and can also be triggered manually from the dashboard.
+
+[[triggers]]
+type           = "post-deploy-component"
+component_name = "rds"
+
+[[triggers]]
+type = "manual"
+
+
+# -----------------------------------------------------------------------------
+# STEPS
+# -----------------------------------------------------------------------------
+# Each step runs a script. Scripts can be inline, from a file, or from a repo.
+
+[[steps]]
+name = "Copy RDS Secret"
+
+# Inline bash script. Supports Nuon template variables in env_vars.
+# The script reads the RDS password from AWS Secrets Manager and creates
+# a Kubernetes secret that pods can mount.
+inline_contents = """
+#!/usr/bin/env bash
+# Copies RDS credentials from AWS Secrets Manager to Kubernetes secret.
+# Environment variables are injected by Nuon from component outputs.
+set -euo pipefail
+
+echo "[rds-secrets] reading db access secrets from AWS Secrets Manager"
+secret=$(aws --region "$REGION" secretsmanager get-secret-value --secret-id="$SECRET_ARN")
+username=$(echo "$secret" | jq -r '.SecretString' | jq -r '.username')
+password=$(echo "$secret" | jq -r '.SecretString' | jq -r '.password')
+
+echo "[rds-secrets] creating RDS access secret"
+kubectl create -n "$TARGET_NAMESPACE" secret generic "$TARGET_NAME" \
+  --save-config    \
+  --dry-run=client \
+  --from-literal=username="$username" \
+  --from-literal=password="$password" \
+  --from-literal=host="$DB_ADDRESS" \
+  --from-literal=port="$DB_PORT" \
+  --from-literal=database="$DB_NAME" \
+  -o yaml | kubectl apply -f -
+
+echo "[rds-secrets] secret created successfully"
+"""
+
+# Environment variables passed to the script.
+# Values support Nuon template variables for dynamic configuration.
+[steps.env_vars]
+# From RDS component outputs (1-rds.toml)
+SECRET_ARN = "{{ .nuon.components.rds.outputs.master_user_secret_arn }}"
+DB_ADDRESS = "{{ .nuon.components.rds.outputs.db_host }}"
+DB_PORT    = "{{ .nuon.components.rds.outputs.db_port }}"
+DB_NAME    = "{{ .nuon.components.rds.outputs.db_name }}"
+# From CloudFormation stack outputs
+REGION     = "{{ .nuon.install_stack.outputs.region }}"
+# Static values
+TARGET_NAME      = "db-credentials"
+TARGET_NAMESPACE = "default"
+
+
+# -----------------------------------------------------------------------------
+# ALTERNATIVE: Script from Repository
+# -----------------------------------------------------------------------------
+# Instead of inline_contents, reference a script file:
+#
+# [[steps]]
+# name    = "Copy RDS Secret"
+# command = "./scripts/copy-rds-secret.sh"
+#
+# [steps.public_repo]
+# repo      = "nuonco/uptime-monitor"
+# directory = "scripts"
+# branch    = "main"
+#
+# [steps.env_vars]
+# SECRET_ARN = "{{ .nuon.components.rds.outputs.master_user_secret_arn }}"

--- a/uptime-monitor/break_glass.toml
+++ b/uptime-monitor/break_glass.toml
@@ -1,0 +1,121 @@
+# =============================================================================
+# NUON BREAK GLASS CONFIGURATION
+# =============================================================================
+#
+# Break glass roles provide temporary elevated access for emergency situations.
+# When an incident requires direct access to the customer's environment, the
+# customer can approve a break glass request via CloudFormation, granting
+# time-limited elevated permissions to the Nuon runner.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=break-glass
+#
+# -----------------------------------------------------------------------------
+# ROLE KEYS
+# -----------------------------------------------------------------------------
+#
+#   type                  (optional)  Role type when using permissions directory
+#   name                  (required)  IAM role name in AWS (supports templating)
+#   description           (required)  Human-readable description of the role's purpose
+#   display_name          (optional)  Display name shown in the installer UI
+#   policies              (required)  List of IAM policies to attach
+#   permissions_boundary  (optional)  ARN of permissions boundary policy
+#
+# -----------------------------------------------------------------------------
+# POLICY KEYS
+# -----------------------------------------------------------------------------
+#
+#   managed_policy_name  (optional)  AWS managed policy name or ARN
+#   name                 (optional)  Name for inline/customer managed policies
+#   contents             (optional)  JSON policy document (inline or file path)
+#
+# Note: Each policy should have either managed_policy_name OR name+contents.
+#
+# -----------------------------------------------------------------------------
+# BEST PRACTICES
+# -----------------------------------------------------------------------------
+#
+# - Use the principle of least privilege for break glass access
+# - Consider separate break glass roles for different access levels:
+#     - Network access (VPC operations)
+#     - Sandbox access (EKS cluster, databases)
+#     - Component access (deployments, pods)
+# - Always include explicit deny statements for sensitive resources
+# - Document the intended use case in the description
+#
+# See: https://docs.nuon.co/production-readiness/break-glass
+#
+# =============================================================================
+
+
+[[role]]
+# IAM role name. Supports Nuon template variables.
+name = "{{.nuon.install.id}}-uptime-sandbox-break-glass"
+
+# Description shown to customers when approving break glass access.
+description = "Grants access to the sandbox for install {{.nuon.install.id}}."
+
+# Display name in the Nuon dashboard.
+display_name = "{{.nuon.install.id}} - Uptime Monitor Sandbox Break Glass"
+
+# Permissions boundary ARN (optional). Limits the maximum permissions this role can have.
+# Can reference a local file or ARN:
+#   permissions_boundary = "./permissions/break_glass_boundary.json"
+#   permissions_boundary = "arn:aws:iam::aws:policy/PowerUserAccess"
+permissions_boundary = ""
+
+
+# -----------------------------------------------------------------------------
+# POLICIES
+# -----------------------------------------------------------------------------
+# Policies attached to this break glass role.
+
+# Attach an AWS managed policy by name or ARN.
+[[role.policies]]
+managed_policy_name = "AdministratorAccess"
+
+# Inline policy with explicit deny for sensitive resources.
+# This ensures Secrets Manager access is blocked even with AdministratorAccess.
+[[role.policies]]
+name = "{{.nuon.install.id}}-break-glass-deny-secrets"
+contents = """
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DenySecretsManagerAccess",
+            "Effect": "Deny",
+            "Action": [
+                "secretsmanager:*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+"""
+
+# Alternative: Reference policy from external file
+# [[role.policies]]
+# name = "{{.nuon.install.id}}-custom-policy"
+# contents = "./permissions/break_glass_policy.json"
+
+
+# -----------------------------------------------------------------------------
+# EXAMPLE: Multiple Break Glass Roles
+# -----------------------------------------------------------------------------
+# You can define multiple roles for different access levels.
+#
+# [[role]]
+# name         = "{{.nuon.install.id}}-network-break-glass"
+# description  = "Grants VPC and networking access for install {{.nuon.install.id}}."
+# display_name = "{{.nuon.install.id}} - Network Break Glass"
+#
+# [[role.policies]]
+# managed_policy_name = "AmazonVPCFullAccess"
+#
+# [[role]]
+# name         = "{{.nuon.install.id}}-eks-break-glass"
+# description  = "Grants EKS cluster access for install {{.nuon.install.id}}."
+# display_name = "{{.nuon.install.id}} - EKS Break Glass"
+#
+# [[role.policies]]
+# managed_policy_name = "AmazonEKSClusterPolicy"

--- a/uptime-monitor/components/0-api-image.toml
+++ b/uptime-monitor/components/0-api-image.toml
@@ -1,0 +1,73 @@
+# =============================================================================
+# NUON DOCKER BUILD COMPONENT - API Image
+# =============================================================================
+#
+# Builds a Docker image from a Dockerfile and syncs it to the customer's
+# container registry (ECR). The built image can be referenced by other
+# components using: {{.nuon.components.api_image.image.repository.uri}}
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=docker-build
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Component identifier for template references
+#   type          (required)  Must be "docker_build"
+#   dockerfile    (required)  Path to Dockerfile (relative to repo directory)
+#   public_repo   (conditional) Public repository configuration
+#   connected_repo (conditional) Private repository configuration
+#   dependencies  (optional)  Components that must be built first
+#   var_name      (optional)  Custom variable name for outputs
+#   env_vars      (optional)  Environment variables for docker build
+#
+# Note: Exactly one of public_repo or connected_repo must be specified.
+#
+# =============================================================================
+
+
+# Component name. Used to reference outputs in other components:
+#   {{.nuon.components.api_image.image.repository.uri}}  - ECR repository URI
+#   {{.nuon.components.api_image.image.tag}}             - Image tag
+name = "api_image"
+
+# Component type for Docker image builds.
+type = "docker_build"
+
+# Path to Dockerfile relative to the repository directory.
+dockerfile = "Dockerfile"
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+# Using a public repository (no authentication required):
+[public_repo]
+repo      = "nuonco/uptime-monitor"
+directory = "api"
+branch    = "main"
+
+# Alternative: Using a connected private repository (requires GitHub connection):
+# [connected_repo]
+# repo      = "your-org/your-private-app"
+# directory = "api"
+# branch    = "main"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Build Arguments / Environment Variables
+# -----------------------------------------------------------------------------
+# Pass environment variables to the Docker build process.
+# Supports Nuon template variables.
+#
+# [env_vars]
+# BUILD_VERSION = "{{.nuon.install.id}}"
+# NODE_ENV      = "production"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Dependencies
+# -----------------------------------------------------------------------------
+# List components that must be built before this one.
+#
+# dependencies = ["base_image"]

--- a/uptime-monitor/components/0-ui-image.toml
+++ b/uptime-monitor/components/0-ui-image.toml
@@ -1,0 +1,54 @@
+# =============================================================================
+# NUON DOCKER BUILD COMPONENT - UI Image
+# =============================================================================
+#
+# Builds a Docker image from a Dockerfile and syncs it to the customer's
+# container registry (ECR). The built image can be referenced by other
+# components using: {{.nuon.components.ui_image.image.repository.uri}}
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=docker-build
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Component identifier for template references
+#   type          (required)  Must be "docker_build"
+#   dockerfile    (required)  Path to Dockerfile (relative to repo directory)
+#   public_repo   (conditional) Public repository configuration
+#   connected_repo (conditional) Private repository configuration
+#   dependencies  (optional)  Components that must be built first
+#   var_name      (optional)  Custom variable name for outputs
+#   env_vars      (optional)  Environment variables for docker build
+#
+# Note: Exactly one of public_repo or connected_repo must be specified.
+#
+# =============================================================================
+
+
+# Component name. Used to reference outputs in other components:
+#   {{.nuon.components.ui_image.image.repository.uri}}  - ECR repository URI
+#   {{.nuon.components.ui_image.image.tag}}             - Image tag
+name = "ui_image"
+
+# Component type for Docker image builds.
+type = "docker_build"
+
+# Path to Dockerfile relative to the repository directory.
+dockerfile = "Dockerfile"
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+# Using a public repository (no authentication required):
+[public_repo]
+repo      = "nuonco/uptime-monitor"
+directory = "ui"
+branch    = "main"
+
+# Alternative: Using a connected private repository (requires GitHub connection):
+# [connected_repo]
+# repo      = "your-org/your-private-app"
+# directory = "ui"
+# branch    = "main"

--- a/uptime-monitor/components/1-irsa.toml
+++ b/uptime-monitor/components/1-irsa.toml
@@ -1,0 +1,70 @@
+# =============================================================================
+# NUON TERRAFORM COMPONENT - IRSA (IAM Roles for Service Accounts)
+# =============================================================================
+#
+# Creates an IAM role that can be assumed by Kubernetes service accounts,
+# enabling pods to access AWS services (S3, RDS, etc.) without static credentials.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=terraform
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name              (required)  Component identifier for template references
+#   type              (required)  Must be "terraform_module"
+#   terraform_version (required)  Terraform version for deployments
+#   dependencies      (optional)  Components that must deploy first
+#   public_repo       (conditional) Public repository configuration
+#   connected_repo    (conditional) Private repository configuration
+#   vars              (optional)  Terraform input variables (supports templating)
+#
+# -----------------------------------------------------------------------------
+# TERRAFORM MODULE LOCATION
+# -----------------------------------------------------------------------------
+#
+# The Terraform code is in: ./1-irsa/main.tf (relative to this file)
+#
+# =============================================================================
+
+
+# Component name. Used to reference outputs:
+#   {{.nuon.components.irsa.outputs.role_arn}}
+name = "irsa"
+
+# Component type for Terraform modules.
+type = "terraform_module"
+
+# Terraform version.
+terraform_version = "1.14.3"
+
+# -----------------------------------------------------------------------------
+# DEPENDENCIES
+# -----------------------------------------------------------------------------
+# This component depends on S3 and RDS to reference their outputs (ARNs) when
+# creating IAM policies. Nuon ensures these deploy first.
+dependencies = ["s3", "rds"]
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "uptime-monitor/components/1-irsa"
+branch    = "main"
+
+
+# -----------------------------------------------------------------------------
+# TERRAFORM VARIABLES
+# -----------------------------------------------------------------------------
+# References outputs from dependent components and sandbox.
+#
+# Component output syntax:
+#   {{.nuon.components.COMPONENT_NAME.outputs.OUTPUT_NAME}}
+#
+[vars]
+region                = "{{ .nuon.install_stack.outputs.region }}"
+install_id            = "{{ .nuon.install.id }}"
+cluster_oidc_provider = "{{ .nuon.install.sandbox.outputs.cluster.oidc_provider }}"
+s3_bucket_arn         = "{{ .nuon.components.s3.outputs.bucket_arn }}"

--- a/uptime-monitor/components/1-irsa/main.tf
+++ b/uptime-monitor/components/1-irsa/main.tf
@@ -1,0 +1,140 @@
+# -----------------------------------------------------------------------------
+# IRSA (IAM Roles for Service Accounts) for Uptime Monitor
+# -----------------------------------------------------------------------------
+#
+# Variables are passed from the Nuon component config (1-irsa.toml):
+#   - var.region                <- {{.nuon.install_stack.outputs.region}}
+#   - var.install_id            <- {{.nuon.install.id}}
+#   - var.cluster_oidc_provider <- {{.nuon.install.sandbox.outputs.cluster.oidc_provider}}
+#   - var.s3_bucket_arn         <- {{.nuon.components.s3.outputs.bucket_arn}}
+#
+# Outputs are available to other components via:
+#   {{.nuon.components.irsa.outputs.role_arn}}
+#
+# This role is referenced in the API manifest's ServiceAccount annotation.
+#
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.27.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  # Nuon tagging convention for resource tracking
+  default_tags {
+    tags = {
+      "install.nuon.co/id"     = var.install_id
+      "component.nuon.co/name" = "irsa"
+    }
+  }
+}
+
+# Variables passed from Nuon component config
+variable "region" {
+  type = string
+}
+
+variable "install_id" {
+  type = string
+}
+
+# From sandbox outputs: {{.nuon.install.sandbox.outputs.cluster.oidc_provider}}
+variable "cluster_oidc_provider" {
+  type        = string
+  description = "EKS cluster OIDC provider for IRSA"
+}
+
+# From s3 component outputs: {{.nuon.components.s3.outputs.bucket_arn}}
+variable "s3_bucket_arn" {
+  type        = string
+  description = "ARN of the S3 bucket to grant access to"
+}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
+data "aws_caller_identity" "current" {}
+
+# IAM policy for S3 bucket access
+data "aws_iam_policy_document" "s3_access" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [var.s3_bucket_arn]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject"
+    ]
+    resources = ["${var.s3_bucket_arn}/*"]
+  }
+}
+
+# IAM policy for RDS access (drift detection demo)
+data "aws_iam_policy_document" "rds_access" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "rds:DescribeDBInstances",
+      "rds:ModifyDBInstance",
+      "rds:AddTagsToResource"
+    ]
+    resources = ["arn:aws:rds:${var.region}:${local.account_id}:db:*"]
+  }
+}
+
+# Trust policy for IRSA
+data "aws_iam_policy_document" "trust_policy" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = ["arn:aws:iam::${local.account_id}:oidc-provider/${var.cluster_oidc_provider}"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${var.cluster_oidc_provider}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${var.cluster_oidc_provider}:sub"
+      values   = ["system:serviceaccount:default:api"]
+    }
+  }
+}
+
+# IAM role for the API service account
+resource "aws_iam_role" "api" {
+  name               = "${var.install_id}-uptime-api-role"
+  assume_role_policy = data.aws_iam_policy_document.trust_policy.json
+
+  inline_policy {
+    name   = "s3-access"
+    policy = data.aws_iam_policy_document.s3_access.json
+  }
+
+  inline_policy {
+    name   = "rds-access"
+    policy = data.aws_iam_policy_document.rds_access.json
+  }
+}
+
+# Outputs - referenced by other Nuon components
+output "role_arn" {
+  value       = aws_iam_role.api.arn
+  description = "IAM role ARN for the API service account"
+}

--- a/uptime-monitor/components/1-rds.toml
+++ b/uptime-monitor/components/1-rds.toml
@@ -1,0 +1,86 @@
+# =============================================================================
+# NUON TERRAFORM COMPONENT - RDS PostgreSQL
+# =============================================================================
+#
+# Deploys a Terraform module to create an RDS PostgreSQL instance. Outputs
+# from this component can be referenced by other components using:
+#   {{.nuon.components.rds.outputs.OUTPUT_NAME}}
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=terraform
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name              (required)  Component identifier for template references
+#   type              (required)  Must be "terraform_module"
+#   terraform_version (required)  Terraform version for deployments
+#   public_repo       (conditional) Public repository configuration
+#   connected_repo    (conditional) Private repository configuration
+#   vars              (optional)  Terraform input variables (supports templating)
+#   var_file          (optional)  External .tfvars files to load
+#   env_vars          (optional)  Environment variables for Terraform
+#   dependencies      (optional)  Components that must deploy first
+#   drift_schedule    (optional)  Cron expression for drift detection
+#
+# Note: Exactly one of public_repo or connected_repo must be specified.
+#
+# -----------------------------------------------------------------------------
+# TERRAFORM MODULE LOCATION
+# -----------------------------------------------------------------------------
+#
+# The Terraform code is in: ./1-rds/main.tf (relative to this file)
+#
+# =============================================================================
+
+
+# Component name. Used to reference outputs:
+#   {{.nuon.components.rds.outputs.endpoint}}
+#   {{.nuon.components.rds.outputs.port}}
+#   {{.nuon.components.rds.outputs.database_name}}
+name = "rds"
+
+# Component type for Terraform modules.
+type = "terraform_module"
+
+# Terraform version.
+terraform_version = "1.14.3"
+
+# -----------------------------------------------------------------------------
+# DRIFT DETECTION
+# -----------------------------------------------------------------------------
+# Detect when RDS configuration has been modified outside of Terraform.
+# This is useful for the drift demo - modify RDS via the /admin panel,
+# then trigger a drift scan to see Nuon detect the changes.
+drift_schedule = "*/10 * * * *"  # Every 10 minutes
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "uptime-monitor/components/1-rds"
+branch    = "main"
+
+
+# -----------------------------------------------------------------------------
+# TERRAFORM VARIABLES
+# -----------------------------------------------------------------------------
+# This component uses sandbox outputs to configure networking.
+#
+# Common sandbox output paths:
+#   {{.nuon.install.sandbox.outputs.vpc.id}}                    - VPC ID
+#   {{.nuon.install.sandbox.outputs.vpc.private_subnet_ids}}    - Private subnet IDs (array)
+#   {{.nuon.install.sandbox.outputs.vpc.public_subnet_ids}}     - Public subnet IDs (array)
+#   {{.nuon.install.sandbox.outputs.cluster.node_security_group_id}} - EKS node SG
+#   {{.nuon.install.sandbox.outputs.cluster.oidc_provider}}     - OIDC provider for IRSA
+#
+# Use `index` to access array elements: {{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 0 }}
+#
+[vars]
+region                 = "{{ .nuon.install_stack.outputs.region }}"
+install_id             = "{{ .nuon.install.id }}"
+vpc_id                 = "{{ .nuon.install.sandbox.outputs.vpc.id }}"
+private_subnet_ids     = "{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+node_security_group_id = "{{ .nuon.install.sandbox.outputs.cluster.node_security_group_id }}"

--- a/uptime-monitor/components/1-rds/main.tf
+++ b/uptime-monitor/components/1-rds/main.tf
@@ -1,0 +1,157 @@
+# -----------------------------------------------------------------------------
+# RDS PostgreSQL for Uptime Monitor
+# -----------------------------------------------------------------------------
+#
+# Variables are passed from the Nuon component config (1-rds.toml):
+#   - var.region                 <- {{.nuon.install_stack.outputs.region}}
+#   - var.install_id             <- {{.nuon.install.id}}
+#   - var.vpc_id                 <- {{.nuon.install.sandbox.outputs.vpc.id}}
+#   - var.private_subnet_ids     <- {{.nuon.install.sandbox.outputs.vpc.private_subnet_ids}}
+#   - var.node_security_group_id <- {{.nuon.install.sandbox.outputs.cluster.node_security_group_id}}
+#
+# Outputs are available to other components via:
+#   {{.nuon.components.rds.outputs.db_host}}
+#   {{.nuon.components.rds.outputs.db_port}}
+#   {{.nuon.components.rds.outputs.db_name}}
+#   {{.nuon.components.rds.outputs.db_username}}
+#   {{.nuon.components.rds.outputs.master_user_secret_arn}}
+#
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.27.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  # Nuon tagging convention for resource tracking
+  default_tags {
+    tags = {
+      "install.nuon.co/id"     = var.install_id
+      "component.nuon.co/name" = "rds"
+    }
+  }
+}
+
+# Variables passed from Nuon component config
+variable "region" {
+  type = string
+}
+
+variable "install_id" {
+  type = string
+}
+
+# From sandbox outputs: {{.nuon.install.sandbox.outputs.vpc.id}}
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID from the sandbox"
+}
+
+# From sandbox outputs: {{.nuon.install.sandbox.outputs.vpc.private_subnet_ids}}
+variable "private_subnet_ids" {
+  type        = string
+  description = "Comma-delimited string of private subnet IDs from the sandbox"
+}
+
+# From sandbox outputs: {{.nuon.install.sandbox.outputs.cluster.node_security_group_id}}
+variable "node_security_group_id" {
+  type        = string
+  description = "EKS node security group ID from the sandbox"
+}
+
+# Get VPC CIDR block
+data "aws_vpc" "vpc" {
+  id = var.vpc_id
+}
+
+# Security group for RDS
+resource "aws_security_group" "postgres" {
+  name_prefix = "${var.install_id}-postgres-"
+  description = "Security group for PostgreSQL RDS instance"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = [data.aws_vpc.vpc.cidr_block]
+    description = "Allow PostgreSQL access from within VPC"
+  }
+
+  tags = {
+    Name = "${var.install_id}-postgres-sg"
+  }
+}
+
+# RDS subnet group
+resource "aws_db_subnet_group" "postgres" {
+  name_prefix = "${var.install_id}-postgres-"
+  subnet_ids  = split(",", var.private_subnet_ids)
+
+  tags = {
+    Name = "${var.install_id}-postgres-subnet-group"
+  }
+}
+
+# RDS PostgreSQL instance
+resource "aws_db_instance" "postgres" {
+  identifier_prefix = "${var.install_id}-postgres-"
+
+  engine         = "postgres"
+  engine_version = "18"
+  instance_class = "db.t3.micro"
+
+  allocated_storage     = 20
+  max_allocated_storage = 20
+  storage_type          = "gp3"
+
+  db_name  = "uptime_monitor"
+  username = "uptime_monitor"
+
+  # AWS manages password in Secrets Manager
+  manage_master_user_password = true
+
+  db_subnet_group_name   = aws_db_subnet_group.postgres.name
+  vpc_security_group_ids = [aws_security_group.postgres.id]
+  publicly_accessible    = false
+
+  deletion_protection = false
+  skip_final_snapshot = true
+
+  tags = {
+    Name = "${var.install_id}-postgres"
+  }
+}
+
+# Outputs - referenced by other Nuon components and actions
+output "db_host" {
+  value       = aws_db_instance.postgres.address
+  description = "PostgreSQL database host"
+}
+
+output "db_port" {
+  value       = aws_db_instance.postgres.port
+  description = "PostgreSQL database port"
+}
+
+output "db_name" {
+  value       = aws_db_instance.postgres.db_name
+  description = "PostgreSQL database name"
+}
+
+output "db_username" {
+  value       = aws_db_instance.postgres.username
+  description = "PostgreSQL database username"
+}
+
+output "master_user_secret_arn" {
+  value       = aws_db_instance.postgres.master_user_secret[0].secret_arn
+  description = "ARN of the Secrets Manager secret containing username/password"
+}

--- a/uptime-monitor/components/1-s3.toml
+++ b/uptime-monitor/components/1-s3.toml
@@ -1,0 +1,97 @@
+# =============================================================================
+# NUON TERRAFORM COMPONENT - S3 Bucket
+# =============================================================================
+#
+# Deploys a Terraform module to create AWS resources. Outputs from this
+# component can be referenced by other components using:
+#   {{.nuon.components.s3.outputs.OUTPUT_NAME}}
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=terraform
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name              (required)  Component identifier for template references
+#   type              (required)  Must be "terraform_module"
+#   terraform_version (required)  Terraform version for deployments
+#   public_repo       (conditional) Public repository configuration
+#   connected_repo    (conditional) Private repository configuration
+#   vars              (optional)  Terraform input variables (supports templating)
+#   var_file          (optional)  External .tfvars files to load
+#   env_vars          (optional)  Environment variables for Terraform
+#   dependencies      (optional)  Components that must deploy first
+#   drift_schedule    (optional)  Cron expression for drift detection
+#
+# Note: Exactly one of public_repo or connected_repo must be specified.
+#
+# -----------------------------------------------------------------------------
+# TERRAFORM MODULE LOCATION
+# -----------------------------------------------------------------------------
+#
+# The Terraform code is in: ./1-s3/main.tf (relative to this file)
+# This component references itself via public_repo pointing to this repo.
+#
+# =============================================================================
+
+
+# Component name. Used to reference outputs:
+#   {{.nuon.components.s3.outputs.bucket_name}}
+#   {{.nuon.components.s3.outputs.bucket_arn}}
+name = "s3"
+
+# Component type for Terraform modules.
+type = "terraform_module"
+
+# Terraform version. Check https://releases.hashicorp.com/terraform/ for versions.
+terraform_version = "1.14.3"
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+# Points to the Terraform module directory.
+# Here we reference the same repo this config lives in.
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "uptime-monitor/components/1-s3"
+branch    = "main"
+
+# Alternative: Using a connected private repository:
+# [connected_repo]
+# repo      = "your-org/terraform-modules"
+# directory = "modules/s3"
+# branch    = "main"
+
+
+# -----------------------------------------------------------------------------
+# TERRAFORM VARIABLES
+# -----------------------------------------------------------------------------
+# Variables passed to the Terraform module. Supports Nuon template variables:
+#
+#   {{.nuon.install.id}}                           - Unique install identifier
+#   {{.nuon.install_stack.outputs.region}}         - AWS region from CF stack
+#   {{.nuon.install.sandbox.outputs.vpc.id}}       - VPC ID from sandbox
+#   {{.nuon.components.COMPONENT.outputs.X}}       - Outputs from other components
+#   {{.nuon.inputs.inputs.INPUT_NAME}}             - User-provided inputs
+#
+[vars]
+region     = "{{ .nuon.install_stack.outputs.region }}"
+install_id = "{{ .nuon.install.id }}"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Variable Files
+# -----------------------------------------------------------------------------
+# Load additional variables from .tfvars files.
+#
+# [[var_file]]
+# contents = "./s3.tfvars"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Drift Detection
+# -----------------------------------------------------------------------------
+# Enable periodic drift detection with a cron schedule.
+#
+# drift_schedule = "0 */6 * * *"  # Every 6 hours

--- a/uptime-monitor/components/1-s3/main.tf
+++ b/uptime-monitor/components/1-s3/main.tf
@@ -1,0 +1,63 @@
+# -----------------------------------------------------------------------------
+# S3 Bucket for Uptime Monitor
+# -----------------------------------------------------------------------------
+#
+# Variables are passed from the Nuon component config (1-s3.toml):
+#   - var.region     <- {{.nuon.install_stack.outputs.region}}
+#   - var.install_id <- {{.nuon.install.id}}
+#
+# Outputs are available to other components via:
+#   {{.nuon.components.s3.outputs.bucket_name}}
+#   {{.nuon.components.s3.outputs.bucket_arn}}
+#
+# -----------------------------------------------------------------------------
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.27.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  # Nuon tagging convention for resource tracking
+  default_tags {
+    tags = {
+      "install.nuon.co/id"     = var.install_id
+      "component.nuon.co/name" = "s3"
+    }
+  }
+}
+
+# Variables passed from Nuon component config
+variable "region" {
+  type = string
+}
+
+variable "install_id" {
+  type = string
+}
+
+locals {
+  bucket_name = "${var.install_id}-uptime-monitor"
+}
+
+# S3 bucket
+resource "aws_s3_bucket" "main" {
+  bucket = local.bucket_name
+}
+
+# Outputs - referenced by other Nuon components
+output "bucket_name" {
+  value       = aws_s3_bucket.main.bucket
+  description = "S3 bucket name"
+}
+
+output "bucket_arn" {
+  value       = aws_s3_bucket.main.arn
+  description = "S3 bucket ARN"
+}

--- a/uptime-monitor/components/2-api.toml
+++ b/uptime-monitor/components/2-api.toml
@@ -1,0 +1,78 @@
+# =============================================================================
+# NUON KUBERNETES MANIFEST COMPONENT - API Deployment
+# =============================================================================
+#
+# Deploys raw Kubernetes YAML manifests to the customer's cluster. The manifest
+# file supports Nuon template variables for dynamic configuration.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=kubernetes-manifest
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Component identifier for template references
+#   type          (required)  Must be "kubernetes_manifest"
+#   namespace     (required)  Kubernetes namespace for deployment
+#   manifest      (required)  Path to manifest YAML or inline YAML content
+#   dependencies  (optional)  Components that must deploy first
+#   public_repo   (optional)  Repository containing manifest (if not local)
+#   connected_repo (optional) Private repository containing manifest
+#   kustomize     (optional)  Kustomize configuration (mutually exclusive with manifest)
+#   drift_schedule (optional) Cron expression for drift detection
+#
+# -----------------------------------------------------------------------------
+# MANIFEST LOCATION
+# -----------------------------------------------------------------------------
+#
+# The Kubernetes manifest is in: ./2-api/manifest.yaml (relative to this file)
+# Manifest supports Nuon template variables for images, secrets, and config.
+#
+# =============================================================================
+
+
+# Component name.
+name = "api"
+
+# Component type for Kubernetes manifests.
+type = "kubernetes_manifest"
+
+# Dependencies ensure the image is built and infrastructure exists before deploying.
+# References: api_image (Docker image), rds (database), s3 (storage), irsa (IAM role)
+dependencies = ["api_image", "rds", "s3", "irsa"]
+
+# Kubernetes namespace. Supports template variables.
+# Example with dynamic namespace: namespace = "{{.nuon.install.id}}"
+namespace = "default"
+
+# Path to manifest file. Supports Nuon template variables inside the YAML.
+# Can also be inline YAML:
+#   manifest = """
+#   apiVersion: v1
+#   kind: ConfigMap
+#   ...
+#   """
+manifest = "./2-api/manifest.yaml"
+
+
+# -----------------------------------------------------------------------------
+# DRIFT DETECTION
+# -----------------------------------------------------------------------------
+# Detect when API deployment has been modified outside of Nuon.
+# Useful for the drift demo - manually scale or modify the deployment via
+# kubectl, then trigger a drift scan to see Nuon detect the changes.
+drift_schedule = "*/10 * * * *"  # Every 10 minutes
+
+
+# -----------------------------------------------------------------------------
+# ALTERNATIVE: Kustomize
+# -----------------------------------------------------------------------------
+# Use Kustomize instead of a raw manifest (mutually exclusive with manifest).
+#
+# [kustomize]
+# directory = "./2-api/kustomize"
+#
+# [kustomize.public_repo]
+# repo      = "nuonco/uptime-monitor"
+# directory = "nuon/uptime-monitor/components/2-api/kustomize"
+# branch    = "main"

--- a/uptime-monitor/components/2-api/manifest.yaml
+++ b/uptime-monitor/components/2-api/manifest.yaml
@@ -1,0 +1,116 @@
+# -----------------------------------------------------------------------------
+# API Deployment for Uptime Monitor
+# -----------------------------------------------------------------------------
+#
+# Nuon template variables used in this manifest:
+#
+#   Service Account (IRSA):
+#     {{ .nuon.components.irsa.outputs.role_arn }}  <- IAM role for AWS access
+#
+#   Container Image (from docker_build component):
+#     {{ .nuon.components.api_image.outputs.image.repository }}
+#     {{ .nuon.components.api_image.outputs.image.tag }}
+#
+#   Environment Variables:
+#     {{ .nuon.install.inputs.healthcheck_interval_seconds }}  <- User input
+#     {{ .nuon.install_stack.outputs.region }}                 <- AWS region
+#     {{ .nuon.components.s3.outputs.bucket_name }}            <- S3 component output
+#
+#   Database credentials come from a Kubernetes secret created by the
+#   rds_creds action (see actions/rds_creds.toml).
+#
+# -----------------------------------------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: api
+  namespace: default
+  annotations:
+    # IRSA: Links this ServiceAccount to an IAM role for AWS API access
+    eks.amazonaws.com/role-arn: "{{ .nuon.components.irsa.outputs.role_arn }}"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      serviceAccountName: api
+      containers:
+        - name: api
+          # Image built by Nuon docker_build component (0-api-image.toml)
+          image: "{{ .nuon.components.api_image.outputs.image.repository }}:{{ .nuon.components.api_image.outputs.image.tag }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          env:
+            # Database credentials from Kubernetes secret (created by rds_creds action)
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: host
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: port
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: database
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-credentials
+                  key: password
+            # User-configurable input from inputs.toml
+            - name: CHECK_INTERVAL
+              value: "{{ .nuon.install.inputs.healthcheck_interval_seconds }}"
+            # AWS region from CloudFormation stack outputs
+            - name: AWS_REGION
+              value: "{{ .nuon.install_stack.outputs.region }}"
+            # S3 bucket name from Terraform component output
+            - name: S3_BUCKET_NAME
+              value: "{{ .nuon.components.s3.outputs.bucket_name }}"
+          livenessProbe:
+            httpGet:
+              path: /livez
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8000
+      targetPort: 8000
+  selector:
+    app: api

--- a/uptime-monitor/components/2-ui.toml
+++ b/uptime-monitor/components/2-ui.toml
@@ -1,0 +1,51 @@
+# =============================================================================
+# NUON KUBERNETES MANIFEST COMPONENT - UI Deployment
+# =============================================================================
+#
+# Deploys raw Kubernetes YAML manifests to the customer's cluster.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=kubernetes-manifest
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Component identifier for template references
+#   type          (required)  Must be "kubernetes_manifest"
+#   namespace     (required)  Kubernetes namespace for deployment
+#   manifest      (required)  Path to manifest YAML or inline YAML content
+#   dependencies  (optional)  Components that must deploy first
+#
+# -----------------------------------------------------------------------------
+# MANIFEST LOCATION
+# -----------------------------------------------------------------------------
+#
+# The Kubernetes manifest is in: ./2-ui/manifest.yaml (relative to this file)
+#
+# =============================================================================
+
+
+# Component name.
+name = "ui"
+
+# Component type for Kubernetes manifests.
+type = "kubernetes_manifest"
+
+# Dependencies ensure the image is built and API is deployed first.
+# The UI depends on the API being available.
+dependencies = ["ui_image", "api"]
+
+# Kubernetes namespace.
+namespace = "default"
+
+# Path to manifest file.
+manifest = "./2-ui/manifest.yaml"
+
+
+# -----------------------------------------------------------------------------
+# DRIFT DETECTION
+# -----------------------------------------------------------------------------
+# Detect when UI deployment has been modified outside of Nuon.
+# Useful for the drift demo - manually scale or modify the deployment via
+# kubectl, then trigger a drift scan to see Nuon detect the changes.
+drift_schedule = "*/10 * * * *"  # Every 10 minutes

--- a/uptime-monitor/components/2-ui/manifest.yaml
+++ b/uptime-monitor/components/2-ui/manifest.yaml
@@ -1,0 +1,59 @@
+# -----------------------------------------------------------------------------
+# UI Deployment for Uptime Monitor
+# -----------------------------------------------------------------------------
+#
+# Nuon template variables used in this manifest:
+#
+#   Container Image (from docker_build component):
+#     {{ .nuon.components.ui_image.outputs.image.repository }}
+#     {{ .nuon.components.ui_image.outputs.image.tag }}
+#
+# -----------------------------------------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ui
+  template:
+    metadata:
+      labels:
+        app: ui
+    spec:
+      containers:
+        - name: ui
+          # Image built by Nuon docker_build component (0-ui-image.toml)
+          image: "{{ .nuon.components.ui_image.outputs.image.repository }}:{{ .nuon.components.ui_image.outputs.image.tag }}"
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 32Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  namespace: default
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 80
+  selector:
+    app: ui

--- a/uptime-monitor/components/3-headlamp.toml
+++ b/uptime-monitor/components/3-headlamp.toml
@@ -1,0 +1,119 @@
+# =============================================================================
+# NUON HELM CHART COMPONENT - Headlamp (Kubernetes Dashboard)
+# =============================================================================
+#
+# Deploys a Helm chart to the customer's cluster. Headlamp provides a web-based
+# Kubernetes dashboard for cluster visibility.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=helm
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name           (required)  Component identifier (also used as Helm release name)
+#   type           (required)  Must be "helm_chart"
+#   chart_name     (required)  Name of the Helm chart
+#   namespace      (optional)  Kubernetes namespace (default: {{.nuon.install.id}})
+#   public_repo    (conditional) Public repository containing the chart
+#   connected_repo (conditional) Private repository containing the chart
+#   helm_repo      (conditional) Helm repository URL (alternative to git repos)
+#   values         (optional)  Inline Helm values as key-value pairs
+#   values_file    (optional)  External values.yaml files to load
+#   storage_driver (optional)  Helm storage backend: "configmap" or "secret"
+#   dependencies   (optional)  Components that must deploy first
+#   take_ownership (optional)  Take ownership of existing release
+#   drift_schedule (optional)  Cron expression for drift detection
+#
+# Note: Exactly one of public_repo, connected_repo, or helm_repo must be specified.
+#
+# =============================================================================
+
+
+# Component name (also the Helm release name).
+name = "headlamp"
+
+# Component type for Helm charts.
+type = "helm_chart"
+
+# Chart name within the repository.
+chart_name = "headlamp"
+
+# Kubernetes namespace for the release.
+namespace = "default"
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+# Using a public Git repository containing the chart:
+[public_repo]
+repo      = "kubernetes-sigs/headlamp"
+directory = "charts/headlamp"
+branch    = "main"
+
+# Alternative: Using a Helm repository URL:
+# [helm_repo]
+# repo_url = "https://kubernetes-sigs.github.io/headlamp"
+# chart    = "headlamp"
+# version  = "0.20.0"    # Optional: pin to specific version
+
+# Alternative: Using a connected private repository:
+# [connected_repo]
+# repo      = "your-org/helm-charts"
+# directory = "charts/headlamp"
+# branch    = "main"
+
+
+# -----------------------------------------------------------------------------
+# DRIFT DETECTION
+# -----------------------------------------------------------------------------
+# Detect when Headlamp Helm release has been modified outside of Nuon.
+# Useful for the drift demo - manually change Helm values or scale the
+# deployment, then trigger a drift scan to see Nuon detect the changes.
+drift_schedule = "*/10 * * * *"  # Every 10 minutes
+
+
+# -----------------------------------------------------------------------------
+# HELM VALUES
+# -----------------------------------------------------------------------------
+# Inline values passed to the chart. Keys use dot notation for nested values.
+# Supports Nuon template variables.
+#
+# To find available values, check the chart's values.yaml or run:
+#   helm show values <repo>/<chart>
+#
+[values]
+"replicaCount"                       = "1"
+"ingress.enabled"                    = "false"
+"config.oidc.secret.create"          = "false"
+"config.oidc.externalSecret.enabled" = "false"
+"clusterRoleBinding.create"          = "true"
+"clusterRoleBinding.clusterRoleName" = "cluster-admin"
+"config.baseURL"                     = "/headlamp"
+"serviceAccount.create"              = "true"
+"persistentVolumeClaim.enabled"      = "false"
+
+# Example with template variables:
+# "config.installId" = "{{.nuon.install.id}}"
+
+
+# -----------------------------------------------------------------------------
+# ALTERNATIVE: Values Files
+# -----------------------------------------------------------------------------
+# Load values from external files instead of inline.
+#
+# [[values_file]]
+# contents = "./values/headlamp.yaml"
+#
+# [[values_file]]
+# contents = "./values/headlamp-production.yaml"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Storage Driver
+# -----------------------------------------------------------------------------
+# Where Helm stores release metadata.
+#
+# storage_driver = "configmap"  # Default, recommended
+# storage_driver = "secret"     # Use if release data is sensitive

--- a/uptime-monitor/components/4-alb.toml
+++ b/uptime-monitor/components/4-alb.toml
@@ -1,0 +1,44 @@
+# =============================================================================
+# NUON KUBERNETES MANIFEST COMPONENT - Application Load Balancer
+# =============================================================================
+#
+# Deploys a Kubernetes Ingress resource that provisions an AWS Application
+# Load Balancer via the AWS Load Balancer Controller.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=kubernetes-manifest
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Component identifier for template references
+#   type          (required)  Must be "kubernetes_manifest"
+#   namespace     (required)  Kubernetes namespace for deployment
+#   manifest      (required)  Path to manifest YAML or inline YAML content
+#   dependencies  (optional)  Components that must deploy first
+#
+# -----------------------------------------------------------------------------
+# MANIFEST LOCATION
+# -----------------------------------------------------------------------------
+#
+# The Kubernetes manifest is in: ./4-alb/manifest.yaml (relative to this file)
+# Contains an Ingress resource with ALB annotations for routing.
+#
+# =============================================================================
+
+
+# Component name.
+name = "application_load_balancer"
+
+# Component type for Kubernetes manifests.
+type = "kubernetes_manifest"
+
+# Kubernetes namespace.
+namespace = "default"
+
+# Dependencies ensure all services are deployed before creating the load balancer.
+# The ALB routes traffic to UI and Headlamp services.
+dependencies = ["ui", "headlamp"]
+
+# Path to manifest file containing the Ingress resource.
+manifest = "./4-alb/manifest.yaml"

--- a/uptime-monitor/components/4-alb/manifest.yaml
+++ b/uptime-monitor/components/4-alb/manifest.yaml
@@ -1,0 +1,50 @@
+# -----------------------------------------------------------------------------
+# Application Load Balancer Ingress for Uptime Monitor
+# -----------------------------------------------------------------------------
+#
+# Nuon template variables used in this manifest:
+#
+#   Labels:
+#     {{ .nuon.install.id }}  <- Unique install identifier
+#
+#   DNS (external-dns annotation):
+#     {{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}
+#
+# This Ingress creates an AWS ALB via the AWS Load Balancer Controller.
+# External-DNS automatically creates a Route53 record for the public domain.
+#
+# -----------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alb
+  namespace: default
+  labels:
+    # Nuon install ID for resource tracking
+    app.nuon.co/install: "{{ .nuon.install.id }}"
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    alb.ingress.kubernetes.io/healthcheck-path: "/"
+    # Public domain from sandbox DNS configuration
+    external-dns.alpha.kubernetes.io/hostname: "{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}"
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /headlamp
+            pathType: Prefix
+            backend:
+              service:
+                name: headlamp
+                port:
+                  number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ui
+                port:
+                  number: 80

--- a/uptime-monitor/components/README.md
+++ b/uptime-monitor/components/README.md
@@ -1,0 +1,87 @@
+# Components
+
+Components are the building blocks of your Nuon app. Each component represents a deployable unit - container images, Helm charts, Kubernetes manifests, or Terraform modules.
+
+## Component Types
+
+| Type                  | Description                            | Use Case                            |
+|-----------------------|----------------------------------------|-------------------------------------|
+| `docker_build`        | Builds Docker images from Dockerfiles  | Custom application images           |
+| `container_image`     | References pre-built container images  | Third-party or pre-built images     |
+| `helm_chart`          | Deploys Helm charts                    | Packaged Kubernetes applications    |
+| `kubernetes_manifest` | Deploys raw Kubernetes YAML            | Custom K8s resources                |
+| `terraform_module`    | Runs Terraform modules                 | Cloud infrastructure (RDS, S3, IAM) |
+
+## Components in This App
+
+### Images (Prefix: 0-)
+
+| Component          | Type           | Description                    |
+|--------------------|----------------|--------------------------------|
+| `0-api-image.toml` | docker_build   | Builds the API container image |
+| `0-ui-image.toml`  | docker_build   | Builds the UI container image  |
+
+### Infrastructure (Prefix: 1-)
+
+| Component      | Type             | Description                              |
+|----------------|------------------|------------------------------------------|
+| `1-s3.toml`    | terraform_module | S3 bucket for file storage               |
+| `1-rds.toml`   | terraform_module | PostgreSQL RDS instance                  |
+| `1-irsa.toml`  | terraform_module | IAM role for Kubernetes service accounts |
+
+### Deployments (Prefix: 2-)
+
+| Component      | Type                | Description                |
+|----------------|---------------------|----------------------------|
+| `2-api.toml`   | kubernetes_manifest | API deployment and service |
+| `2-ui.toml`    | kubernetes_manifest | UI deployment and service  |
+
+### Additional Services (Prefix: 3+)
+
+| Component          | Type                | Description                       |
+|--------------------|---------------------|-----------------------------------|
+| `3-headlamp.toml`  | helm_chart          | Kubernetes dashboard              |
+| `4-alb.toml`       | kubernetes_manifest | Application Load Balancer ingress |
+
+## Deployment Order
+
+Components are deployed based on their dependencies. The numeric prefix indicates the general deployment tier:
+
+```
+0-*  Images are built first (no dependencies)
+ │
+ ├── 1-s3, 1-rds  Infrastructure components
+ │        │
+ │        └── 1-irsa  (depends on s3, rds)
+ │              │
+ └──────────────┼── 2-api  (depends on api_image, rds, s3, irsa)
+                │     │
+                │     └── 2-ui  (depends on ui_image, api)
+                │           │
+                └───────────┴── 3-headlamp
+                                    │
+                                    └── 4-alb  (depends on ui, headlamp)
+```
+
+## Referencing Component Outputs
+
+Components can reference outputs from other components using template variables:
+
+```toml
+# Reference a Terraform output
+bucket_name = "{{ .nuon.components.s3.outputs.bucket_name }}"
+
+# Reference a Docker image
+image = "{{ .nuon.components.api_image.outputs.image.repository }}:{{ .nuon.components.api_image.outputs.image.tag }}"
+
+# Reference sandbox outputs
+vpc_id = "{{ .nuon.install.sandbox.outputs.vpc.id }}"
+```
+
+## Documentation
+
+- [Components Overview](https://docs.nuon.co/concepts/components)
+- [Terraform Components](https://docs.nuon.co/guides/terraform-components)
+- [Helm Components](https://docs.nuon.co/guides/helm-components)
+- [Kubernetes Manifest Components](https://docs.nuon.co/guides/kubernetes-manifest-components)
+- [Docker Build Components](https://docs.nuon.co/guides/docker-build-components)

--- a/uptime-monitor/inputs.toml
+++ b/uptime-monitor/inputs.toml
@@ -1,0 +1,115 @@
+# =============================================================================
+# NUON APP INPUTS CONFIGURATION
+# =============================================================================
+#
+# Inputs allow customers to configure their install. Values are collected
+# during installation and can be referenced throughout your app config using
+# template variables: {{.nuon.install.inputs.INPUT_NAME}}
+#
+# Schema (input):       https://api.nuon.co/v1/general/config-schema?type=input
+# Schema (input-group): https://api.nuon.co/v1/general/config-schema?type=input-group
+#
+# -----------------------------------------------------------------------------
+# INPUT GROUP KEYS
+# -----------------------------------------------------------------------------
+#
+#   name          (required)  Group identifier (referenced by inputs)
+#   description   (required)  Human-readable description for the installer UI
+#   display_name  (optional)  Human-readable name shown in the installer UI
+#
+# -----------------------------------------------------------------------------
+# INPUT KEYS
+# -----------------------------------------------------------------------------
+#
+#   name              (required)  Input identifier for template references
+#   display_name      (required)  Human-readable name in the installer UI
+#   description       (required)  Explanation of what this input is for
+#   group             (required)  Name of the input group this belongs to
+#   default           (optional)  Default value if customer doesn't provide one
+#   required          (optional)  Whether customer must provide a value (default: false)
+#   sensitive         (optional)  Mask value in UI (for passwords/tokens)
+#   type              (optional)  Data type: "string", "number", "bool", "list", "json"
+#   internal          (optional)  Only settable via admin panel (hidden from customers)
+#   user_configurable (optional)  Can be modified after installation
+#
+# -----------------------------------------------------------------------------
+# ALTERNATIVE: Directory-Based Configuration
+# -----------------------------------------------------------------------------
+#
+# Instead of a single inputs.toml, you can use directories:
+#   - inputs/           Individual input files (e.g., inputs/api_token.toml)
+#   - input_groups/     Individual group files (e.g., input_groups/network.toml)
+#
+# When using directories, omit the [[input]] and [[group]] array syntax.
+#
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# INPUT GROUPS
+# -----------------------------------------------------------------------------
+# Groups organize inputs in the installer UI for better UX.
+
+[[group]]
+name         = "monitoring"
+description  = "Configure monitoring settings"
+display_name = "Monitoring"
+
+# Example: Additional group for network settings
+# [[group]]
+# name         = "network"
+# description  = "Configure network and connectivity settings"
+# display_name = "Network"
+
+
+# -----------------------------------------------------------------------------
+# INPUTS
+# -----------------------------------------------------------------------------
+
+[[input]]
+name              = "healthcheck_interval_seconds"
+description       = "How often to check site uptime (in seconds)"
+display_name      = "Healthcheck Interval (seconds)"
+group             = "monitoring"
+default           = "5"
+required          = false
+type              = "number"
+user_configurable = true    # Allows customers to change this after install
+
+# Example: Required string input
+# [[input]]
+# name         = "root_domain"
+# description  = "Root domain for the application (e.g., example.com)"
+# display_name = "Root Domain"
+# group        = "network"
+# required     = true
+# type         = "string"
+
+# Example: Sensitive input (value masked in UI)
+# [[input]]
+# name         = "api_token"
+# description  = "API token for external service integration"
+# display_name = "API Token"
+# group        = "integrations"
+# required     = true
+# sensitive    = true
+# type         = "string"
+
+# Example: Boolean input
+# [[input]]
+# name         = "enable_debug"
+# description  = "Enable debug logging"
+# display_name = "Enable Debug Mode"
+# group        = "monitoring"
+# default      = "false"
+# type         = "bool"
+
+# Example: Internal input (admin-only, hidden from customers)
+# [[input]]
+# name         = "feature_flag_beta"
+# description  = "Enable beta features"
+# display_name = "Beta Features"
+# group        = "internal"
+# default      = "false"
+# type         = "bool"
+# internal     = true

--- a/uptime-monitor/metadata.toml
+++ b/uptime-monitor/metadata.toml
@@ -1,0 +1,66 @@
+# =============================================================================
+# NUON APP METADATA CONFIGURATION
+# =============================================================================
+#
+# This file defines metadata for your Nuon application. Metadata is displayed
+# in the Nuon Dashboard and Installer UI to help users understand your app.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=metadata
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   version          (required)  Config file format version ("v1" or "v2")
+#   display_name     (optional)  Human-readable name shown in the installer UI
+#   description      (optional)  Detailed description displayed in the installer
+#   readme           (optional)  Path to README.md or inline markdown content
+#   slack_webhook_url (optional) Slack webhook URL for deployment notifications
+#
+# =============================================================================
+
+
+# Config file format version. Use "v2" for new apps.
+#
+# Available versions:
+#   "v1" - Legacy format
+#   "v2" - Current format (recommended)
+#
+version = "v2"
+
+
+# Human-readable application name displayed in the Nuon Dashboard and Installer.
+display_name = "Uptime Monitor"
+
+
+# Detailed description of your application. This appears in the installer UI
+# to help users understand what your app does.
+description = "A demo uptime monitoring service."
+
+
+# README documentation for your app. Can be either:
+#   - A path to a markdown file:  readme = "./README.md"
+#   - Inline markdown content:    readme = """# My App\n\nDescription here..."""
+#
+# The README is rendered in the Dashboard for each app and its installs.
+# Supports GitHub-flavored markdown and basic HTML/CSS.
+#
+# READMEs support Nuon template variables (rendered per-install):
+#   {{.nuon.app.name}}                    - App name
+#   {{.nuon.install.name}}                - Install name
+#   {{.nuon.install.id}}                  - Install ID
+#   {{.nuon.sandbox.type}}                - Sandbox type (e.g., "aws-eks")
+#   {{.nuon.components.COMPONENT.status}} - Component deployment status
+#
+# Full Golang templating is supported, including conditionals and loops:
+#   {{ if .nuon.components.populated }}...{{ end }}
+#   {{ range $name, $c := .nuon.components.components }}...{{ end }}
+readme = "./README.md"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Slack Notifications
+# -----------------------------------------------------------------------------
+# Receive deployment notifications in Slack. Uncomment and add your webhook URL.
+#
+# slack_webhook_url = "https://hooks.slack.com/services/foo/bar/baz"

--- a/uptime-monitor/permissions/README.md
+++ b/uptime-monitor/permissions/README.md
@@ -1,0 +1,103 @@
+# Permissions
+
+IAM roles used by the Nuon runner during different phases of the install lifecycle. These roles are created in the customer's AWS account via the CloudFormation stack.
+
+## Lifecycle Phases
+
+| Phase       | Role File          | When Used                                         |
+|-------------|--------------------|---------------------------------------------------|
+| Provision   | `provision.toml`   | Initial install - creating sandbox and components |
+| Maintenance | `maintenance.toml` | Day-to-day operations - deployments, updates      |
+| Deprovision | `deprovision.toml` | Teardown - destroying components and sandbox      |
+
+## How It Works
+
+1. When a customer runs the CloudFormation stack, these IAM roles are created in their account
+2. The Nuon runner assumes the appropriate role for each operation
+3. Permission boundaries limit the maximum permissions each role can have
+4. This ensures least-privilege access during each lifecycle phase
+
+## Files in This Directory
+
+| File                        | Description                                    |
+|-----------------------------|------------------------------------------------|
+| `provision.toml`            | IAM role for provisioning operations           |
+| `maintenance.toml`          | IAM role for maintenance operations            |
+| `deprovision.toml`          | IAM role for deprovision operations            |
+| `provision_boundary.json`   | Permission boundary for provision role         |
+| `maintenance_boundary.json` | Permission boundary for maintenance role       |
+| `deprovision_boundary.json` | Permission boundary for deprovision role       |
+
+## Configuration Keys
+
+```toml
+type                 = "provision"           # Role type: provision, maintenance, deprovision
+name                 = "{{.nuon.install.id}}-provision"  # IAM role name (supports templating)
+description          = "Role description"    # Shown to customers in installer
+display_name         = "Display Name"        # UI display name
+permissions_boundary = "./boundary.json"    # Path to boundary policy
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"  # AWS managed policy
+
+[[policies]]
+name = "custom-policy"                       # Custom inline policy
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [...]
+}
+"""
+```
+
+## Best Practices
+
+**Principle of Least Privilege**: While this demo uses `AdministratorAccess` for simplicity, production apps should use scoped policies:
+
+```toml
+# Example: Scoped provision role
+[[policies]]
+name = "provision-eks"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "eks:CreateCluster",
+        "eks:DeleteCluster",
+        "eks:DescribeCluster",
+        "eks:UpdateClusterConfig"
+      ],
+      "Resource": "arn:aws:eks:*:*:cluster/{{.nuon.install.id}}-*"
+    }
+  ]
+}
+"""
+```
+
+**Permission Boundaries**: Use boundaries to set maximum allowed permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["eks:*", "ec2:*", "s3:*", "rds:*"],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Deny",
+      "Action": ["iam:CreateUser", "iam:DeleteUser"],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## Documentation
+
+- [Install Access Permissions](https://docs.nuon.co/guides/install-access-permissions)
+- [Permissions Reference](https://docs.nuon.co/config-ref/permissions)

--- a/uptime-monitor/permissions/deprovision.toml
+++ b/uptime-monitor/permissions/deprovision.toml
@@ -1,0 +1,52 @@
+# =============================================================================
+# NUON DEPROVISION ROLE
+# =============================================================================
+#
+# IAM role used when tearing down an install. This role is assumed by the Nuon
+# runner when deleting components and destroying the sandbox infrastructure.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=permissions
+#
+# =============================================================================
+
+
+type                 = "deprovision"
+name                 = "{{ .nuon.install.id }}-deprovision"
+description          = "{{ .nuon.install.id }} deprovision role for the Uptime Monitor install"
+display_name         = "{{ .nuon.install.id }}-deprovision"
+permissions_boundary = "./deprovision_boundary.json"
+
+
+# -----------------------------------------------------------------------------
+# POLICIES
+# -----------------------------------------------------------------------------
+
+# AWS managed policy (broad access for demo purposes)
+[[policies]]
+managed_policy_name = "AdministratorAccess"
+
+# Alternative: Scoped policy for production (delete-focused)
+# [[policies]]
+# name = "{{.nuon.install.id}}-deprovision-policy"
+# contents = """
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Action": ["eks:DeleteCluster", "eks:DeleteNodegroup", "eks:Describe*"],
+#       "Resource": "*"
+#     },
+#     {
+#       "Effect": "Allow",
+#       "Action": ["s3:DeleteBucket", "s3:DeleteObject", "s3:ListBucket"],
+#       "Resource": "arn:aws:s3:::{{.nuon.install.id}}-*"
+#     },
+#     {
+#       "Effect": "Allow",
+#       "Action": ["rds:DeleteDBInstance", "rds:Describe*"],
+#       "Resource": "*"
+#     }
+#   ]
+# }
+# """

--- a/uptime-monitor/permissions/deprovision_boundary.json
+++ b/uptime-monitor/permissions/deprovision_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/uptime-monitor/permissions/maintenance.toml
+++ b/uptime-monitor/permissions/maintenance.toml
@@ -1,0 +1,48 @@
+# =============================================================================
+# NUON MAINTENANCE ROLE
+# =============================================================================
+#
+# IAM role used during day-to-day operations. This role is assumed by the Nuon
+# runner when deploying component updates, running actions, and performing
+# routine maintenance tasks.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=permissions
+#
+# =============================================================================
+
+
+type                 = "maintenance"
+name                 = "{{ .nuon.install.id }}-maintenance"
+description          = "{{ .nuon.install.id }} maintenance role for the Uptime Monitor install"
+display_name         = "{{ .nuon.install.id }}-maintenance"
+permissions_boundary = "./maintenance_boundary.json"
+
+
+# -----------------------------------------------------------------------------
+# POLICIES
+# -----------------------------------------------------------------------------
+
+# AWS managed policy (broad access for demo purposes)
+[[policies]]
+managed_policy_name = "AdministratorAccess"
+
+# Alternative: Scoped policy for production (read-heavy, limited write)
+# [[policies]]
+# name = "{{.nuon.install.id}}-maintenance-policy"
+# contents = """
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Action": ["eks:Describe*", "eks:List*", "eks:UpdateNodegroupConfig"],
+#       "Resource": "*"
+#     },
+#     {
+#       "Effect": "Allow",
+#       "Action": ["s3:GetObject", "s3:PutObject", "s3:ListBucket"],
+#       "Resource": "arn:aws:s3:::{{.nuon.install.id}}-*"
+#     }
+#   ]
+# }
+# """

--- a/uptime-monitor/permissions/maintenance_boundary.json
+++ b/uptime-monitor/permissions/maintenance_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/uptime-monitor/permissions/provision.toml
+++ b/uptime-monitor/permissions/provision.toml
@@ -1,0 +1,55 @@
+# =============================================================================
+# NUON PROVISION ROLE
+# =============================================================================
+#
+# IAM role used during initial install provisioning. This role is assumed by
+# the Nuon runner when creating the sandbox and deploying components for the
+# first time.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=permissions
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   type                 (required)  Role type: "provision", "maintenance", "deprovision"
+#   name                 (required)  IAM role name in AWS (supports templating)
+#   description          (required)  Human-readable description for customers
+#   display_name         (optional)  Display name in the installer UI
+#   permissions_boundary (optional)  Path to permission boundary policy
+#   policies             (required)  List of IAM policies to attach
+#
+# =============================================================================
+
+
+type                 = "provision"
+name                 = "{{ .nuon.install.id }}-provision"
+description          = "{{ .nuon.install.id }} provision role for the Uptime Monitor install"
+display_name         = "{{ .nuon.install.id }}-provision"
+permissions_boundary = "./provision_boundary.json"
+
+
+# -----------------------------------------------------------------------------
+# POLICIES
+# -----------------------------------------------------------------------------
+# Policies attached to this role. Can use AWS managed policies or inline policies.
+
+# AWS managed policy (broad access for demo purposes)
+[[policies]]
+managed_policy_name = "AdministratorAccess"
+
+# Alternative: Scoped inline policy for production
+# [[policies]]
+# name = "{{.nuon.install.id}}-provision-policy"
+# contents = """
+# {
+#   "Version": "2012-10-17",
+#   "Statement": [
+#     {
+#       "Effect": "Allow",
+#       "Action": ["eks:*", "ec2:*", "s3:*", "rds:*", "iam:*"],
+#       "Resource": "*"
+#     }
+#   ]
+# }
+# """

--- a/uptime-monitor/permissions/provision_boundary.json
+++ b/uptime-monitor/permissions/provision_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/uptime-monitor/runner.toml
+++ b/uptime-monitor/runner.toml
@@ -1,0 +1,62 @@
+# =============================================================================
+# NUON RUNNER CONFIGURATION
+# =============================================================================
+#
+# The runner is the Nuon agent that executes deployments in the customer's
+# cloud account. It communicates with the Nuon control plane and manages
+# Helm releases, Kubernetes manifests, and Terraform operations.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=runner
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   runner_type      (required)  Type of runner ("aws" or "azure")
+#   helm_driver      (optional)  Helm storage backend ("configmap" or "secret")
+#   init_script_url  (optional)  URL to runner initialization script
+#   env_vars         (optional)  Environment variables passed to the runner
+#
+# =============================================================================
+
+
+# Type of runner. Determines the cloud platform for deployment.
+#
+# Available types:
+#   "aws"   - Amazon Web Services
+#   "azure" - Microsoft Azure
+runner_type = "aws"
+
+
+# Helm storage driver for release metadata.
+#
+# Available drivers:
+#   "configmap" - Store release data in ConfigMaps (default, recommended)
+#   "secret"    - Store release data in Secrets (use if release data is sensitive)
+helm_driver = "configmap"
+
+
+# Initialization script executed when the runner starts.
+# This script configures the runner environment (e.g., installs tools, sets up auth).
+#
+# Nuon provides managed init scripts:
+#   - Standard mode:    .../scripts/aws/init.sh
+#   - Management mode:  .../scripts/aws/init-mng.sh (recommended for new installs)
+#
+# See: https://docs.nuon.co/guides/runner-management-mode
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng.sh"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Environment Variables
+# -----------------------------------------------------------------------------
+# Environment variables available to the runner and all jobs it executes.
+#
+# [env_vars]
+# LOG_LEVEL = "debug"
+# CUSTOM_VAR = "value"
+#
+# Alternative array syntax for environment variables:
+# [[env_var]]
+# name  = "LOG_LEVEL"
+# value = "debug"

--- a/uptime-monitor/sandbox.tfvars
+++ b/uptime-monitor/sandbox.tfvars
@@ -1,0 +1,25 @@
+maintenance_role_eks_access_entry_policy_associations = {
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_view = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+
+additional_namespaces = []
+
+additional_tags = {
+  "app.nuon.co/name" : "uptime-monitor"
+}
+
+eks_compute_config = {
+  enabled    = true
+  node_pools = ["general-purpose", "system"]
+}

--- a/uptime-monitor/sandbox.toml
+++ b/uptime-monitor/sandbox.toml
@@ -1,0 +1,142 @@
+# =============================================================================
+# NUON SANDBOX CONFIGURATION
+# =============================================================================
+#
+# The sandbox is the base infrastructure layer for your app (e.g., VPC, EKS
+# cluster, networking). Nuon provisions this using Terraform in the customer's
+# cloud account.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=sandbox
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   terraform_version  (required)  Terraform version to use for deployments
+#   public_repo        (conditional) Public repository configuration
+#   connected_repo     (conditional) Private repository configuration (GitHub)
+#   vars               (optional)  Terraform input variables (supports templating)
+#   var_file           (optional)  External Terraform variable files to load
+#   env_vars           (optional)  Environment variables passed to Terraform
+#   drift_schedule     (optional)  Cron expression for periodic drift detection
+#
+# Note: Exactly one of public_repo or connected_repo must be specified.
+#
+# -----------------------------------------------------------------------------
+# AVAILABLE NUON SANDBOXES
+# -----------------------------------------------------------------------------
+#
+# Nuon provides managed sandbox modules:
+#   - nuonco/aws-eks-sandbox         Standard EKS with node groups
+#   - nuonco/aws-eks-auto-sandbox    EKS with Auto Mode (used here)
+#   - nuonco/aws-eks-karpenter-sandbox  EKS with Karpenter autoscaling
+#   - nuonco/aws-min-sandbox         Minimal AWS (no K8s, for Lambda/ECS)
+#   - nuonco/azure-aks-sandbox       Azure AKS
+#
+# See: https://github.com/nuonco for full list and documentation
+#
+# =============================================================================
+
+
+# Terraform version for provisioning the sandbox infrastructure.
+terraform_version = "1.14.3"
+
+
+# -----------------------------------------------------------------------------
+# REPOSITORY CONFIGURATION
+# -----------------------------------------------------------------------------
+# Source repository containing the Terraform module for the sandbox.
+#
+# Using a public repository (no authentication required):
+[public_repo]
+repo      = "nuonco/aws-eks-auto-sandbox"
+branch    = "main"
+directory = "."
+
+# Alternative: Using a connected private repository (requires GitHub connection):
+# [connected_repo]
+# repo      = "your-org/your-private-sandbox"
+# branch    = "main"
+# directory = "terraform/sandbox"
+
+
+# -----------------------------------------------------------------------------
+# TERRAFORM VARIABLES
+# -----------------------------------------------------------------------------
+# Variables passed to the Terraform module. Supports Nuon template variables:
+#
+#   {{.nuon.install.id}}                  - Unique install identifier
+#   {{.nuon.install.name}}                - Install name
+#   {{.nuon.install_stack.outputs.X}}     - CloudFormation stack outputs
+#   {{.nuon.inputs.inputs.INPUT_NAME}}    - User-provided inputs
+#   {{.nuon.cloud_account.aws.region}}    - AWS region
+#
+[vars]
+# EKS cluster configuration
+cluster_version = "1.33"
+cluster_name    = "{{.nuon.install.id}}"
+
+# -----------------------------------------------------------------------------
+# DNS Configuration
+# -----------------------------------------------------------------------------
+# Nuon can manage DNS for your installs via Route53.
+#
+# When enable_nuon_dns = "true":
+#   - Nuon creates a Route53 hosted zone for each install
+#   - External-DNS controller syncs Ingress annotations to Route53 records
+#   - Domains are subdomains of nuon.run
+#
+# Example: If install ID is "abc123xyz", the domains would be:
+#   - Public:   abc123xyz.nuon.run
+#   - Internal: abc123xyz.internal.nuon.run
+#
+# Sandbox outputs available to components:
+#   {{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}    - Public domain
+#   {{.nuon.install.sandbox.outputs.nuon_dns.internal_domain.name}}  - Internal domain
+#   {{.nuon.install.sandbox.outputs.nuon_dns.zone_id}}               - Route53 zone ID
+#
+enable_nuon_dns      = "true"
+public_root_domain   = "{{.nuon.install.id}}.nuon.run"
+internal_root_domain = "{{.nuon.install.id}}.internal.nuon.run"
+
+# Alternative: Customer-provided domain via inputs (requires customer DNS setup):
+# enable_nuon_dns      = "false"
+# public_root_domain   = "{{.nuon.inputs.inputs.root_domain}}"
+# internal_root_domain = "internal.{{.nuon.inputs.inputs.root_domain}}"
+
+# Network configuration from the install stack (CloudFormation outputs)
+region = "{{.nuon.install_stack.outputs.region}}"
+vpc_id = "{{.nuon.install_stack.outputs.vpc_id}}"
+
+
+# -----------------------------------------------------------------------------
+# VARIABLE FILES
+# -----------------------------------------------------------------------------
+# Additional Terraform variable files. Can reference local files or remote URLs.
+#
+# Supported sources:
+#   - Local file:    "./sandbox.tfvars"
+#   - HTTP(S) URL:   "https://example.com/vars.tfvars"
+#   - Git reference: "git::https://github.com/org/repo//path/to/file.tfvars"
+#
+[[var_file]]
+contents = "./sandbox.tfvars"
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Drift Detection
+# -----------------------------------------------------------------------------
+# Enable periodic drift detection with a cron schedule.
+# If not set, drift detection is disabled.
+#
+# drift_schedule = "0 */6 * * *"  # Every 6 hours
+
+
+# -----------------------------------------------------------------------------
+# OPTIONAL: Environment Variables
+# -----------------------------------------------------------------------------
+# Environment variables passed to Terraform during execution.
+#
+# [env_vars]
+# TF_LOG = "DEBUG"
+# AWS_MAX_ATTEMPTS = "10"

--- a/uptime-monitor/stack.toml
+++ b/uptime-monitor/stack.toml
@@ -1,0 +1,70 @@
+# =============================================================================
+# NUON INSTALL STACK CONFIGURATION
+# =============================================================================
+#
+# The install stack is the AWS CloudFormation stack that customers deploy to
+# bootstrap Nuon in their account. It creates the VPC, networking, and runner
+# infrastructure needed for your app.
+#
+# Schema: https://api.nuon.co/v1/general/config-schema?type=stack
+#
+# -----------------------------------------------------------------------------
+# CONFIGURATION KEYS
+# -----------------------------------------------------------------------------
+#
+#   type                        (optional)  Stack type ("aws-cloudformation")
+#   name                        (required)  CloudFormation stack name (supports templating)
+#   description                 (required)  Stack description (supports templating)
+#   vpc_nested_template_url     (optional)  URL to VPC nested stack template
+#   runner_nested_template_url  (optional)  URL to runner nested stack template
+#
+# -----------------------------------------------------------------------------
+# CLOUDFORMATION TEMPLATES
+# -----------------------------------------------------------------------------
+#
+# Nuon provides versioned CloudFormation templates:
+#   https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/
+#
+# Template versions follow semver (e.g., v0.1.8). Check release notes for updates.
+#
+# VPC templates (vpc_nested_template_url):
+#   - .../vpc/eks/default/stack.yaml    Standard EKS VPC (used here)
+#   - .../vpc/ecs/default/stack.yaml    ECS VPC
+#   - .../vpc/minimal/stack.yaml        Minimal VPC
+#
+# Runner templates (runner_nested_template_url):
+#   - .../runner/asg/stack.yaml         Auto Scaling Group runner (recommended)
+#   - .../runner/ecs/stack.yaml         ECS-based runner
+#
+# =============================================================================
+
+
+# Stack type. This file is AWS-specific.
+# For Azure, Nuon auto-generates ARM/Bicep templates from sandbox.toml config.
+# See: https://docs.nuon.co/platform-support/azure
+type = "aws-cloudformation"
+
+
+# CloudFormation stack name. Supports Nuon template variables.
+# This name appears in the customer's AWS CloudFormation console.
+name = "nuon-uptime-monitor-{{.nuon.install.id}}"
+
+
+# Stack description shown in CloudFormation console and install QuickLink.
+# Supports Nuon template variables.
+description = "QuickLink to install runner for the Uptime Monitor app config: Install {{.nuon.install.id}}"
+
+
+# -----------------------------------------------------------------------------
+# NESTED STACK TEMPLATES
+# -----------------------------------------------------------------------------
+# URLs to CloudFormation nested stack templates hosted by Nuon.
+# These create the VPC and runner infrastructure in the customer's account.
+
+# VPC nested stack: Creates VPC, subnets, NAT gateways, and networking.
+vpc_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.1.8/vpc/eks/default/stack.yaml"
+
+# Runner nested stack: Creates the Nuon runner (EC2 Auto Scaling Group).
+# Use v0.1.6+ for management mode support.
+# See: https://docs.nuon.co/guides/runner-management-mode
+runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.1.8/runner/asg/stack.yaml"


### PR DESCRIPTION
Adds a new app config that makes it easy to demo certain features of the platform.

Deploys a typical webapp stack:

* Python Backend
* Javascript Frontend
* RDS
* S3

and also includes:

* Headlamp

Includes heavy documentation of the app config toml files. 