### PR TITLE
feat(gke-simple): add policy to require gke node pool service account

### DIFF
--- a/gke-simple/policies.toml
+++ b/gke-simple/policies.toml
@@ -1,0 +1,4 @@
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/gke-node-pool-service-account.rego"

--- a/gke-simple/policies/gke-node-pool-service-account.rego
+++ b/gke-simple/policies/gke-node-pool-service-account.rego
@@ -1,0 +1,64 @@
+# GKE Node Pool Service Account Policy
+#
+# This policy ensures that GKE node pools use a dedicated service account
+# instead of the default Compute Engine service account, which has the
+# overly permissive Editor role.
+#
+# Use Case:
+# - Enforce principle of least privilege on GKE nodes
+# - Prevent use of the default Compute Engine SA (Editor role)
+# - Comply with GKE hardening guidelines
+#
+# Policy Type: terraform_module
+# Engine: opa
+#
+# Example violation:
+# ```hcl
+# resource "google_container_node_pool" "bad" {
+#   node_config {
+#     # No service_account specified — defaults to Compute Engine SA
+#     oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+#   }
+# }
+# ```
+
+package nuon
+
+import future.keywords.contains
+import future.keywords.if
+import future.keywords.in
+
+# Deny node pools without an explicit service account
+deny contains msg if {
+    some resource_change in input.plan.resource_changes
+    resource_change.type == "google_container_node_pool"
+    resource_change.change.actions[_] in ["create", "update"]
+
+    resource := resource_change.change.after
+
+    # service_account is missing or empty
+    not resource.node_config[0].service_account
+
+    msg := sprintf(
+        "GKE node pool '%s' does not specify a service account. This defaults to the Compute Engine SA which has Editor role. Create a dedicated least-privilege service account.",
+        [resource_change.address]
+    )
+}
+
+# Deny node pools without an explicit service account
+warn contains msg if {
+    some resource_change in input.plan.resource_changes
+    resource_change.type == "google_container_node_pool"
+    resource_change.change.actions[_] in ["create", "update"]
+
+    resource := resource_change.change.after
+    sa := resource.node_config[0].service_account
+
+    # Match the default Compute Engine SA pattern
+    endswith(sa, "-compute@developer.gserviceaccount.com")
+
+    msg := sprintf(
+        "GKE node pool '%s' uses the default Compute Engine service account ('%s'). This SA has the Editor role and is overly permissive. Use a dedicated least-privilege service account.",
+        [resource_change.address, sa]
+    )
+}

--- a/gke-simple/sandbox.toml
+++ b/gke-simple/sandbox.toml
@@ -10,6 +10,7 @@ cluster_name         = "n-{{.nuon.install.id}}"
 enable_nuon_dns      = "false"
 public_root_domain   = "{{ .nuon.inputs.inputs.domain }}"
 internal_root_domain = "internal.{{ .nuon.inputs.inputs.domain }}"
+gke_node_pool_sa_email = "{{.nuon.install_stack.outputs.gke_node_pool_sa_email}}"
 
 [[var_file]]
 contents = "./sandbox.tfvars"


### PR DESCRIPTION
## Problem

The new gke-simple sanbox requires a service account for it's node pool. This will be provided by the updated gcp install stack.

## Solution

Update our gke-example apps to pull the valu

Depends on this PR in the policies repo: https://github.com/nuonco/policies/pull/3