### PR TITLE
feat(operation-roles-demo): add operation roles example app

### DIFF
--- a/operation-roles-demo/README.md
+++ b/operation-roles-demo/README.md
@@ -1,0 +1,125 @@
+<center>
+<h1>Operation Roles Demo</h1>
+Every sandbox, component, and action operation runs under a dedicated per-operation IAM role.
+
+Nuon Install Id: {{ .nuon.install.id }}
+
+AWS Region: {{ .nuon.install_stack.outputs.region }}
+
+</center>
+
+## What This Demonstrates
+
+Operation roles let you assign a specific IAM role to each individual operation the Nuon runner performs. Instead of one all-purpose maintenance role, each component/action workflow gets its own role scoped to the AWS APIs it actually calls.
+
+The runner selects a role using this precedence chain:
+
+| Priority | Source | Scope |
+|----------|--------|-------|
+| 1 (highest) | Runtime override (`--role` flag / dashboard) | Any operation |
+| 2 | Entity role (inline `[[operation_roles]]` or `role` field) | Single entity |
+| 3 | Matrix rule (`operation_roles.toml`) | App-wide |
+| 4 (lowest) | Default role (`permissions/provision.toml`, etc.) | App-wide |
+
+This app uses **entity roles** (inline `[[operation_roles]]` blocks on components, `role` field on actions) for every non-sandbox operation. The matrix-rule mechanism (priority 3) is supported by Nuon but is not used here — see the Nuon docs for its syntax.
+
+> **Note:** Sandbox operations use the default provision/maintenance/deprovision roles (not custom operation roles) because the sandbox terraform creates the EKS cluster and needs kubectl access during the same apply. Custom roles would lack EKS access entries until the cluster grants them — a bootstrapping problem.
+
+### IAM vs. EKS access entries
+
+Two layers of authorization are at play:
+
+- **AWS IAM** — the policies attached to each custom role in `permissions/*.toml` control which AWS APIs the role can call (e.g., `eks:DescribeCluster`, `acm:RequestCertificate`, `route53:*`).
+- **EKS access entries** — once the role can call `eks:DescribeCluster` and assume kubectl, Kubernetes RBAC is controlled separately via `additional_access_entry` in `sandbox.tfvars`. That block maps each custom role ARN to an EKS policy (e.g., `AmazonEKSClusterAdminPolicy` cluster-wide, or `AmazonEKSViewPolicy` scoped to the `whoami` namespace for the read-only action).
+
+The custom role IAM policies are intentionally thin on EKS actions (just `DescribeCluster`) because the meaningful kubectl authority is granted at the EKS layer, not the IAM layer.
+
+---
+
+## Role Map
+
+### Sandbox (`sandbox.toml`)
+
+Uses default roles from `permissions/provision.toml`, `maintenance.toml`, and `deprovision.toml`.
+
+### Components
+
+| Component | Operation | Role | Permission Boundary |
+|-----------|-----------|------|---------------------|
+| `whoami` (helm) | `deploy` | `{{.nuon.install.id}}-whoami-deploy` | `provision_boundary.json` |
+| `whoami` (helm) | `teardown` | `{{.nuon.install.id}}-whoami-teardown` | `deprovision_boundary.json` |
+| `alb` (helm) | `deploy` | `{{.nuon.install.id}}-alb-deploy` | `provision_boundary.json` |
+| `alb` (helm) | `teardown` | `{{.nuon.install.id}}-alb-teardown` | `deprovision_boundary.json` |
+| `certificate` (terraform) | `deploy` | `{{.nuon.install.id}}-certificate-deploy` | `provision_boundary.json` |
+| `certificate` (terraform) | `teardown` | `{{.nuon.install.id}}-certificate-teardown` | `deprovision_boundary.json` |
+
+### Actions
+
+| Action | Role | Permission Boundary |
+|--------|------|---------------------|
+| `deployments_status` (read-only) | `{{.nuon.install.id}}-deployments-status-trigger` | `maintenance_boundary.json` |
+| `deployment_restart` (write) | `{{.nuon.install.id}}-deployment-restart-trigger` | `maintenance_boundary.json` |
+
+Note the contrast: `deployments_status` only needs `eks:DescribeCluster` while `deployment_restart` also needs EKS edit access via its cluster access entry.
+
+---
+
+## File Structure
+
+```
+.
+├── runner.toml                    # Runner config (AWS)
+├── stack.toml                     # CloudFormation stack
+├── sandbox.toml                   # EKS sandbox (default roles)
+├── sandbox.tfvars                 # Cluster vars + custom role access entries
+├── metadata.toml                  # App metadata
+├── inputs.toml                    # User-facing inputs (domain)
+│
+├── components/
+│   ├── whoami.toml                # Helm chart with deploy/teardown roles
+│   ├── alb.toml                   # ALB ingress with deploy/teardown roles
+│   ├── certificate.toml           # Terraform module with deploy/teardown roles
+│   └── values/
+│       └── whoami.yaml            # Helm values for whoami
+│
+├── actions/
+│   ├── deployments_status.toml    # Read-only action (view role)
+│   └── deployment_restart.toml    # Write action (edit role)
+│
+├── permissions/
+│   ├── provision.toml             # Default provision role
+│   ├── maintenance.toml           # Default maintenance role
+│   ├── deprovision.toml           # Default deprovision role
+│   ├── sandbox-provision.toml     # Custom: sandbox provision
+│   ├── sandbox-maintenance.toml   # Custom: sandbox reprovision
+│   ├── sandbox-deprovision.toml   # Custom: sandbox deprovision
+│   ├── whoami-deploy.toml         # Custom: whoami deploy
+│   ├── whoami-teardown.toml       # Custom: whoami teardown
+│   ├── alb-deploy.toml            # Custom: alb deploy
+│   ├── alb-teardown.toml          # Custom: alb teardown
+│   ├── certificate-deploy.toml    # Custom: certificate deploy
+│   ├── certificate-teardown.toml  # Custom: certificate teardown
+│   ├── deployments-status-trigger.toml
+│   ├── deployment-restart-trigger.toml
+│   ├── provision_boundary.json    # Boundary for provision/deploy ops
+│   ├── deprovision_boundary.json  # Boundary for teardown/deprovision ops
+│   └── maintenance_boundary.json  # Boundary for action triggers
+└
+```
+
+---
+
+## App URL
+
+[https://{{.nuon.inputs.inputs.sub_domain}}.{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}](https://{{.nuon.inputs.inputs.sub_domain}}.{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}})
+
+```bash
+curl https://{{.nuon.inputs.inputs.sub_domain}}.{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}
+```
+
+---
+
+<details>
+<summary>Full Install State</summary>
+<pre>{{ toPrettyJson .nuon }}</pre>
+</details>

--- a/operation-roles-demo/actions/deployment_restart.toml
+++ b/operation-roles-demo/actions/deployment_restart.toml
@@ -1,0 +1,53 @@
+# action
+name    = "deployment_restart"
+timeout = "45s"
+role    = "{{.nuon.install.id}}-deployment-restart-trigger"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name    = "restart"
+inline_contents = """
+#!/usr/bin/env bash
+
+set -e
+set -o pipefail
+set -u
+
+DEPLOYMENT_NAMESPACE="whoami"
+DEPLOYMENT_NAME="whoami"
+
+echo >&2 "restarting one deployment..."
+
+
+# restart deployment
+kubectl --namespace $DEPLOYMENT_NAMESPACE get deployments/$DEPLOYMENT_NAME |\
+  tail +2          |\
+  cut -d ' '  -f 1 |\
+  xargs -I % sh -c "kubectl --namespace ${DEPLOYMENT_NAMESPACE} rollout restart deployment %"
+
+exit_code="$?"
+sleep 5
+
+payload='{"pre": '$exit_code'}'
+echo $payload >> $NUON_ACTIONS_OUTPUT_FILEPATH
+"""
+
+[[steps]]
+name    = "status"
+inline_contents = """
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+# table for logs
+kubectl get -n whoami deployments
+
+# json for outputs
+response=`kubectl get -n whoami deployments -o json | jq -c`
+
+echo $response >> $NUON_ACTIONS_OUTPUT_FILEPATH
+"""

--- a/operation-roles-demo/actions/deployments_status.toml
+++ b/operation-roles-demo/actions/deployments_status.toml
@@ -1,0 +1,25 @@
+# action
+name    = "deployments_status"
+timeout = "30s"
+role    = "{{.nuon.install.id}}-deployments-status-trigger"
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name    = "status"
+inline_contents = """
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+# table for logs
+kubectl get -n whoami deployments
+
+# json for outputs
+response=`kubectl get -n whoami deployments -o json | jq -c`
+
+echo $response >> $NUON_ACTIONS_OUTPUT_FILEPATH
+"""

--- a/operation-roles-demo/components/alb.toml
+++ b/operation-roles-demo/components/alb.toml
@@ -1,0 +1,28 @@
+# helm
+name           = "application_load_balancer"
+type           = "helm_chart"
+chart_name     = "application-load-balancer"
+dependencies   = ["whoami", "certificate"]
+
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "eks-simple/src/components/alb"
+branch    = "main"
+
+[values]
+domain_certificate = "{{.nuon.components.certificate.outputs.public_domain_certificate_arn}}"
+domain             = "{{.nuon.inputs.inputs.sub_domain}}.{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}"
+https_port         = "443"
+service_name       = "whoami"
+service_port       = "80"
+install_name       = "{{.nuon.install.id}}"
+namespace          = "whoami"
+healthcheck_path   = "/health"
+
+[[operation_roles]]
+operation = "deploy"
+role      = "{{.nuon.install.id}}-alb-deploy"
+
+[[operation_roles]]
+operation = "teardown"
+role      = "{{.nuon.install.id}}-alb-teardown"

--- a/operation-roles-demo/components/certificate.toml
+++ b/operation-roles-demo/components/certificate.toml
@@ -1,0 +1,24 @@
+# terraform
+
+name              = "certificate"
+type              = "terraform_module"
+terraform_version = "1.11.3"
+
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "eks-simple/src/components/certificate"
+branch    = "main"
+
+[vars]
+install_id  = "{{ .nuon.install.id }}"
+region      = "{{ .nuon.install_stack.outputs.region }}"
+zone_id     = "{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.zone_id }}"
+domain_name = "*.{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}"
+
+[[operation_roles]]
+operation = "deploy"
+role      = "{{.nuon.install.id}}-certificate-deploy"
+
+[[operation_roles]]
+operation = "teardown"
+role      = "{{.nuon.install.id}}-certificate-teardown"

--- a/operation-roles-demo/components/values/whoami.yaml
+++ b/operation-roles-demo/components/values/whoami.yaml
@@ -1,0 +1,12 @@
+---
+namespace: "whoami"
+
+image:
+  tag: "latest"
+  repository: "traefik/whoami"
+
+deployment:
+  containerPort: 8000
+
+service:
+  port: 80

--- a/operation-roles-demo/components/whoami.toml
+++ b/operation-roles-demo/components/whoami.toml
@@ -1,0 +1,22 @@
+# helm
+name           = "whoami"
+type           = "helm_chart"
+chart_name     = "whoami"
+namespace      = "whoami"
+storage_driver = "configmap"
+
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "eks-simple/src/components/whoami"
+branch    = "main"
+
+[[values_file]]
+contents = "./values/whoami.yaml"
+
+[[operation_roles]]
+operation = "deploy"
+role      = "{{.nuon.install.id}}-whoami-deploy"
+
+[[operation_roles]]
+operation = "teardown"
+role      = "{{.nuon.install.id}}-whoami-teardown"

--- a/operation-roles-demo/inputs.toml
+++ b/operation-roles-demo/inputs.toml
@@ -1,0 +1,19 @@
+# inputs
+[[group]]
+name         = "dns"
+description  = "DNS Configrations"
+display_name = "Configurations for the root domain for Route53"
+
+[[input]]
+name         = "domain"
+description  = "domain for the whoami endpoint e.g., nuon.run"
+default      = "nuon.run"
+display_name = "Domain"
+group        = "dns"
+
+[[input]]
+name         = "sub_domain"
+description  = "The sub domain for the Whoami service"
+default      = "whoami"
+display_name = "Sub Domain"
+group        = "dns"

--- a/operation-roles-demo/metadata.toml
+++ b/operation-roles-demo/metadata.toml
@@ -1,0 +1,5 @@
+version = "v2"
+
+display_name = "Operation Roles Demo"
+description  = "Demonstrates per-operation IAM role assignment on AWS EKS"
+readme       = "./README.md"

--- a/operation-roles-demo/permissions/alb-deploy.toml
+++ b/operation-roles-demo/permissions/alb-deploy.toml
@@ -1,0 +1,38 @@
+type = "custom"
+name = "{{.nuon.install.id}}-alb-deploy"
+description = "deploy the alb component."
+display_name = "alb deploy role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-alb-deploy"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EKSAuth",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/alb-teardown.toml
+++ b/operation-roles-demo/permissions/alb-teardown.toml
@@ -1,0 +1,38 @@
+type = "custom"
+name = "{{.nuon.install.id}}-alb-teardown"
+description = "teardown the alb component."
+display_name = "alb teardown role"
+permissions_boundary = "./deprovision_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-alb-teardown"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EKSAuth",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/certificate-deploy.toml
+++ b/operation-roles-demo/permissions/certificate-deploy.toml
@@ -1,0 +1,55 @@
+type = "custom"
+name = "{{.nuon.install.id}}-certificate-deploy"
+description = "deploy the certificate component."
+display_name = "certificate deploy role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-certificate-deploy"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ACM",
+      "Effect": "Allow",
+      "Action": [
+        "acm:RequestCertificate",
+        "acm:DescribeCertificate",
+        "acm:GetCertificate",
+        "acm:AddTagsToCertificate",
+        "acm:ListCertificates",
+        "acm:ListTagsForCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Route53",
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetHostedZone",
+        "route53:ListHostedZones",
+        "route53:ChangeResourceRecordSets",
+        "route53:GetChange",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/certificate-teardown.toml
+++ b/operation-roles-demo/permissions/certificate-teardown.toml
@@ -1,0 +1,53 @@
+type = "custom"
+name = "{{.nuon.install.id}}-certificate-teardown"
+description = "teardown the certificate component."
+display_name = "certificate teardown role"
+permissions_boundary = "./deprovision_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-certificate-teardown"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ACM",
+      "Effect": "Allow",
+      "Action": [
+        "acm:DescribeCertificate",
+        "acm:DeleteCertificate",
+        "acm:ListCertificates",
+        "acm:ListTagsForCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Route53",
+      "Effect": "Allow",
+      "Action": [
+        "route53:GetHostedZone",
+        "route53:ListHostedZones",
+        "route53:ChangeResourceRecordSets",
+        "route53:GetChange",
+        "route53:ListResourceRecordSets"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/deployment-restart-trigger.toml
+++ b/operation-roles-demo/permissions/deployment-restart-trigger.toml
@@ -1,0 +1,23 @@
+type = "custom"
+name = "{{.nuon.install.id}}-deployment-restart-trigger"
+description = "trigger the deployment_restart action."
+display_name = "deployment restart trigger role"
+permissions_boundary = "./maintenance_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-deployment-restart-trigger"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EKSAuth",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/deployments-status-trigger.toml
+++ b/operation-roles-demo/permissions/deployments-status-trigger.toml
@@ -1,0 +1,23 @@
+type = "custom"
+name = "{{.nuon.install.id}}-deployments-status-trigger"
+description = "trigger the deployments_status action."
+display_name = "deployments status trigger role"
+permissions_boundary = "./maintenance_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-deployments-status-trigger"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EKSAuth",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/deprovision.toml
+++ b/operation-roles-demo/permissions/deprovision.toml
@@ -1,0 +1,8 @@
+type = "deprovision"
+name = "{{.nuon.install.id}}-deprovision"
+description = "deprovision sandbox and components. you must still delete the cf stack to delete the runner, ec2 vm, and vpc."
+display_name = "deprovision role"
+permissions_boundary = "./deprovision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/operation-roles-demo/permissions/deprovision_boundary.json
+++ b/operation-roles-demo/permissions/deprovision_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/operation-roles-demo/permissions/maintenance.toml
+++ b/operation-roles-demo/permissions/maintenance.toml
@@ -1,0 +1,8 @@
+type                 = "maintenance"
+name                 = "{{ .nuon.install.id }}-maintenance"
+description          = "operate and remediate the app's components and use actions."
+display_name         = "maintenance role"
+permissions_boundary = "./maintenance_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/operation-roles-demo/permissions/maintenance_boundary.json
+++ b/operation-roles-demo/permissions/maintenance_boundary.json
@@ -1,0 +1,42 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCommonActions",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:*",
+        "logs:*",
+        "ec2:*",
+        "eks:*",
+        "iam:*",
+        "rds:*",
+        "s3:*",
+        "secretsmanager:*",
+        "sqs:*",
+        "ecr:*",
+        "acm:*",
+        "Route53:*",
+        "kms:*",
+        "organizations:DescribeOrganization",
+        "elasticloadbalancing:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "DenyS3ObjectActions",
+      "Effect": "Deny",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetObjectVersion",
+        "s3:GetObjectAcl",
+        "s3:PutObjectAcl",
+        "s3:RestoreObject"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/operation-roles-demo/permissions/provision.toml
+++ b/operation-roles-demo/permissions/provision.toml
@@ -1,0 +1,9 @@
+type = "provision"
+name = "{{.nuon.install.id}}-provision"
+description = "provision the sandbox and components; trigger actions."
+display_name = "provision role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"
+

--- a/operation-roles-demo/permissions/provision_boundary.json
+++ b/operation-roles-demo/permissions/provision_boundary.json
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": "*",
+        "Resource": "*"
+      }
+    ]
+  }
+  

--- a/operation-roles-demo/permissions/sandbox-deprovision.toml
+++ b/operation-roles-demo/permissions/sandbox-deprovision.toml
@@ -1,0 +1,8 @@
+type = "custom"
+name = "{{.nuon.install.id}}-sandbox-deprovision"
+description = "deprovision the sandbox."
+display_name = "sandbox deprovision role"
+permissions_boundary = "./deprovision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/operation-roles-demo/permissions/sandbox-maintenance.toml
+++ b/operation-roles-demo/permissions/sandbox-maintenance.toml
@@ -1,0 +1,8 @@
+type = "custom"
+name = "{{.nuon.install.id}}-sandbox-maintenance"
+description = "reprovision and maintain the sandbox."
+display_name = "sandbox maintenance role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/operation-roles-demo/permissions/sandbox-provision.toml
+++ b/operation-roles-demo/permissions/sandbox-provision.toml
@@ -1,0 +1,8 @@
+type = "custom"
+name = "{{.nuon.install.id}}-sandbox-provision"
+description = "provision the sandbox."
+display_name = "sandbox provision role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/operation-roles-demo/permissions/whoami-deploy.toml
+++ b/operation-roles-demo/permissions/whoami-deploy.toml
@@ -1,0 +1,38 @@
+type = "custom"
+name = "{{.nuon.install.id}}-whoami-deploy"
+description = "deploy the whoami component."
+display_name = "whoami deploy role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-whoami-deploy"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EKSAuth",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/permissions/whoami-teardown.toml
+++ b/operation-roles-demo/permissions/whoami-teardown.toml
@@ -1,0 +1,38 @@
+type = "custom"
+name = "{{.nuon.install.id}}-whoami-teardown"
+description = "teardown the whoami component."
+display_name = "whoami teardown role"
+permissions_boundary = "./deprovision_boundary.json"
+
+[[policies]]
+name = "{{.nuon.install.id}}-whoami-teardown"
+contents = """
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ECR",
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:PutImage"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "EKSAuth",
+      "Effect": "Allow",
+      "Action": [
+        "eks:DescribeCluster"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+"""

--- a/operation-roles-demo/runner.toml
+++ b/operation-roles-demo/runner.toml
@@ -1,0 +1,4 @@
+# runner
+runner_type     = "aws"
+helm_driver     = "configmap"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng-v2.sh"

--- a/operation-roles-demo/sandbox.tfvars
+++ b/operation-roles-demo/sandbox.tfvars
@@ -1,0 +1,111 @@
+cluster_endpoint_public_access = true
+
+maintenance_role_eks_access_entry_policy_associations = {
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_view = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+
+additional_namespaces = ["whoami"]
+
+maintenance_cluster_role_rules_override = [{
+  "apiGroups" = ["*"]
+  "resources" = ["*"]
+  "verbs"     = ["*"]
+}]
+
+min_size = 2
+max_size = 3
+desired_size = 2
+
+{{ if gt (len .nuon.install_stack.outputs.custom_role_arns) 0 }}
+additional_access_entry = {
+  whoami_deploy = {
+    principal_arn     = "{{ index .nuon.install_stack.outputs.custom_role_arns (printf "%s-whoami-deploy" .nuon.install.id) }}"
+    kubernetes_groups = []
+    policy_associations = {
+      cluster_admin = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+        access_scope = {
+          type       = "cluster"
+          namespaces = []
+        }
+      }
+    }
+  }
+  whoami_teardown = {
+    principal_arn     = "{{ index .nuon.install_stack.outputs.custom_role_arns (printf "%s-whoami-teardown" .nuon.install.id) }}"
+    kubernetes_groups = []
+    policy_associations = {
+      cluster_admin = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+        access_scope = {
+          type       = "cluster"
+          namespaces = []
+        }
+      }
+    }
+  }
+  deployments_status_trigger = {
+    principal_arn     = "{{ index .nuon.install_stack.outputs.custom_role_arns (printf "%s-deployments-status-trigger" .nuon.install.id) }}"
+    kubernetes_groups = []
+    policy_associations = {
+      view = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSViewPolicy"
+        access_scope = {
+          type       = "namespace"
+          namespaces = ["whoami"]
+        }
+      }
+    }
+  }
+  alb_deploy = {
+    principal_arn     = "{{ index .nuon.install_stack.outputs.custom_role_arns (printf "%s-alb-deploy" .nuon.install.id) }}"
+    kubernetes_groups = []
+    policy_associations = {
+      cluster_admin = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+        access_scope = {
+          type       = "cluster"
+          namespaces = []
+        }
+      }
+    }
+  }
+  alb_teardown = {
+    principal_arn     = "{{ index .nuon.install_stack.outputs.custom_role_arns (printf "%s-alb-teardown" .nuon.install.id) }}"
+    kubernetes_groups = []
+    policy_associations = {
+      cluster_admin = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+        access_scope = {
+          type       = "cluster"
+          namespaces = []
+        }
+      }
+    }
+  }
+  deployment_restart_trigger = {
+    principal_arn     = "{{ index .nuon.install_stack.outputs.custom_role_arns (printf "%s-deployment-restart-trigger" .nuon.install.id) }}"
+    kubernetes_groups = []
+    policy_associations = {
+      cluster_admin = {
+        policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+        access_scope = {
+          type       = "cluster"
+          namespaces = []
+        }
+      }
+    }
+  }
+}
+{{ end }}

--- a/operation-roles-demo/sandbox.toml
+++ b/operation-roles-demo/sandbox.toml
@@ -1,0 +1,17 @@
+terraform_version = "1.11.3"
+
+[public_repo]
+directory = "."
+repo      = "nuonco/aws-eks-sandbox"
+branch    = "main"
+
+[vars]
+cluster_name    = "n-{{.nuon.install.id}}"
+cluster_version = "1.34"
+
+enable_nuon_dns      = "true"
+public_root_domain   = "{{ .nuon.install.id }}.{{.nuon.inputs.inputs.domain}}"
+internal_root_domain = "internal.{{ .nuon.install.id }}.{{.nuon.inputs.inputs.domain}}"
+
+[[var_file]]
+contents = "./sandbox.tfvars"

--- a/operation-roles-demo/src/components/certificate/README.md
+++ b/operation-roles-demo/src/components/certificate/README.md
@@ -1,0 +1,30 @@
+# Certificate
+
+Component to provision an AWS Certificate Manager SSL Certificate.
+
+## Inputs/Variables
+
+| Variable      | Description                                          | Example                                                   |
+| ------------- | ---------------------------------------------------- | --------------------------------------------------------- |
+| `zone_id`     | The ID of the zone. Can be sourced from the sandbox. | `{{.nuon.install.sandbox.outputs.public_domain.zone_id}}` |
+| `domain_name` | The domain name. Usually provided by the sandbox.    | `{{.nuon.install.sandbox.outputs.public_domain.name}}`    |
+
+## Example Configuration
+
+```toml
+name = "certificate"
+type = "terraform_module"
+terraform_version = "1.10.4"
+
+[public_repo]
+repo      = "nuonco/components"
+directory = "aws/certificate"
+branch    = "main"
+
+[vars]
+zone_id     = "{{.nuon.install.sandbox.outputs.public_domain.zone_id}}"
+domain_name = "{{.nuon.install.sandbox.outputs.public_domain.name}}"
+# NOTE: it is also possible to use a subdomain or wildcard here.
+# domain_name = "subdomain.{{.nuon.install.sandbox.outputs.public_domain.name}}"
+# domain_name = "*.{{.nuon.install.sandbox.outputs.public_domain.name}}"
+```

--- a/operation-roles-demo/src/components/certificate/main.tf
+++ b/operation-roles-demo/src/components/certificate/main.tf
@@ -1,0 +1,9 @@
+module "certificate" {
+  source  = "terraform-aws-modules/acm/aws"
+  version = "~> 4.0"
+
+  domain_name         = var.domain_name
+  zone_id             = var.zone_id
+  validation_method   = "DNS"
+  wait_for_validation = false
+}

--- a/operation-roles-demo/src/components/certificate/outputs.tf
+++ b/operation-roles-demo/src/components/certificate/outputs.tf
@@ -1,0 +1,3 @@
+output "public_domain_certificate_arn" {
+  value = module.certificate.acm_certificate_arn
+}

--- a/operation-roles-demo/src/components/certificate/providers.tf
+++ b/operation-roles-demo/src/components/certificate/providers.tf
@@ -1,0 +1,10 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      "install.nuon.co/id"     = var.install_id
+      "component.nuon.co/name" = "certificate"
+    }
+  }
+}

--- a/operation-roles-demo/src/components/certificate/variables.tf
+++ b/operation-roles-demo/src/components/certificate/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  type = string
+}
+
+variable "install_id" {
+  type = string
+}
+
+variable "domain_name" {
+  type = string
+}
+
+variable "zone_id" {
+  type = string
+}

--- a/operation-roles-demo/src/components/certificate/versions.tf
+++ b/operation-roles-demo/src/components/certificate/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.67.0"
+    }
+  }
+}

--- a/operation-roles-demo/src/components/whoami/Chart.yaml
+++ b/operation-roles-demo/src/components/whoami/Chart.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v2
+name: whoami
+description: A helm chart to deploy whoami.
+type: application
+version: v0.0.1
+appVersion: "0.0.1"
+
+dependencies: []

--- a/operation-roles-demo/src/components/whoami/templates/deployment.yaml
+++ b/operation-roles-demo/src/components/whoami/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whoami
+  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+  labels:
+    app: whoami
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: whoami
+  template:
+    metadata:
+      labels:
+        app: whoami
+    spec:
+      containers:
+      - name: whoami
+        image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+        env:
+        - name: "WHOAMI_PORT_NUMBER"
+          value: "{{ .Values.deployment.containerPort }}"
+        ports:
+        - containerPort: {{ .Values.deployment.containerPort }}
+        resources:
+          limits:
+            cpu: ".25"
+            memory: "128Mi"
+          requests:
+            cpu: ".1"
+            memory: "64Mi"
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.deployment.containerPort }}
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: {{ .Values.deployment.containerPort }}
+          initialDelaySeconds: 5
+          periodSeconds: 5

--- a/operation-roles-demo/src/components/whoami/templates/service.yaml
+++ b/operation-roles-demo/src/components/whoami/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+  namespace: {{ .Values.namespace | default .Release.Namespace | quote }}
+spec:
+  ports:
+  - name: http-whoami
+    port: 80
+    protocol: TCP
+    targetPort: {{ .Values.deployment.containerPort }}
+  selector:
+    app: whoami
+  sessionAffinity: None
+  type: ClusterIP

--- a/operation-roles-demo/stack.toml
+++ b/operation-roles-demo/stack.toml
@@ -1,0 +1,7 @@
+type        = "aws-cloudformation"
+name        = "nuon-operation-roles-{{.nuon.install.id}}"
+description = "Operation Roles Demo: per-operation least-privilege IAM for BYOC apps"
+
+# nested stack
+vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.2.0/vpc/eks/default/stack.yaml"
+runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.2.0/runner/asg/stack.yaml"


### PR DESCRIPTION
Mirrors matt-zach-s/operation-roles-demo. Demonstrates per-operation IAM role assignment for sandbox, components, and actions on AWS EKS, with custom permission boundaries and EKS access entries scoped per role.