### PR TITLE
feat: add max_auto_retries = 5 to all eligible components

### DIFF
--- a/aca-simple/components/0-tf-aca-environment.toml
+++ b/aca-simple/components/0-tf-aca-environment.toml
@@ -2,6 +2,7 @@
 name              = "aca_environment"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aca-simple/components/1-tf-whoami.toml
+++ b/aca-simple/components/1-tf-whoami.toml
@@ -3,6 +3,7 @@ name              = "whoami"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["aca_environment"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aks-simple/components/cert_manager.toml
+++ b/aks-simple/components/cert_manager.toml
@@ -5,6 +5,7 @@ type         = "helm_chart"
 chart_name   = "cert-manager"
 namespace    = "cert-manager"
 dependencies = ["dns_records"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aks-simple/components/cert_manager_issuer.toml
+++ b/aks-simple/components/cert_manager_issuer.toml
@@ -5,6 +5,7 @@ type         = "helm_chart"
 chart_name   = "cert-manager-issuer"
 namespace    = "cert-manager"
 dependencies = ["cert_manager"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aks-simple/components/dns_records.toml
+++ b/aks-simple/components/dns_records.toml
@@ -4,6 +4,7 @@ name              = "dns_records"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["nginx_ingress_controller"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aks-simple/components/ingress.toml
+++ b/aks-simple/components/ingress.toml
@@ -4,6 +4,7 @@ name         = "ingress"
 type         = "helm_chart"
 chart_name   = "ingress"
 dependencies = ["whoami"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aks-simple/components/nginx_ingress_controller.toml
+++ b/aks-simple/components/nginx_ingress_controller.toml
@@ -4,6 +4,7 @@ name       = "nginx_ingress_controller"
 type       = "helm_chart"
 chart_name = "nginx-ingress-controller"
 namespace  = "ingress-nginx"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aks-simple/components/whoami.toml
+++ b/aks-simple/components/whoami.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "whoami"
 namespace      = "whoami"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aws-lambda/components/0-docker-image.toml
+++ b/aws-lambda/components/0-docker-image.toml
@@ -3,6 +3,7 @@ name   = "docker_image"
 type = "docker_build"
 
 dockerfile = "Dockerfile"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aws-lambda/components/1-dynamodb-table.toml
+++ b/aws-lambda/components/1-dynamodb-table.toml
@@ -2,6 +2,7 @@
 name              = "dynamodb_table"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aws-lambda/components/2-lambda-function.toml
+++ b/aws-lambda/components/2-lambda-function.toml
@@ -3,6 +3,7 @@ name              = "lambda_function"
 type              = "terraform_module"
 terraform_version = "1.11.4"
 dependencies      = ["dynamodb_table"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aws-lambda/components/3-certificate.toml
+++ b/aws-lambda/components/3-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/aws-lambda/components/4-api-gateway.toml
+++ b/aws-lambda/components/4-api-gateway.toml
@@ -2,6 +2,7 @@
 name              = "api_gateway"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/baserow/components/0-default-storage-class.toml
+++ b/baserow/components/0-default-storage-class.toml
@@ -19,3 +19,4 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 """
+max_auto_retries = 5

--- a/baserow/components/0-s3-bucket.toml
+++ b/baserow/components/0-s3-bucket.toml
@@ -2,6 +2,7 @@
 name              = "baserow_s3_bucket"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/baserow/components/1-baserow.toml
+++ b/baserow/components/1-baserow.toml
@@ -5,6 +5,7 @@ chart_name     = "baserow"
 namespace      = "baserow"
 storage_driver = "configmap"
 dependencies   = ["default_storage_class", "baserow_s3_bucket"]
+max_auto_retries = 5
 
 [helm_repo]
 repo_url = "https://charts.christianhuth.de"

--- a/baserow/components/2-certificate.toml
+++ b/baserow/components/2-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/baserow/components/3-alb-frontend.toml
+++ b/baserow/components/3-alb-frontend.toml
@@ -3,6 +3,7 @@ name         = "frontend_alb"
 type         = "helm_chart"
 chart_name   = "frontend-load-balancer"
 dependencies = ["certificate", "baserow"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/baserow/components/4-alb-backend.toml
+++ b/baserow/components/4-alb-backend.toml
@@ -3,6 +3,7 @@ name         = "backend_alb"
 type         = "helm_chart"
 chart_name   = "backend-load-balancer"
 dependencies = ["certificate", "baserow"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/byo-eks/components/0-configmap-persimmon.toml
+++ b/byo-eks/components/0-configmap-persimmon.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "persimmon"
 
 manifest = "./manifests/persimmon-configmap.yaml"
+max_auto_retries = 5

--- a/byo-eks/components/0-configmap-sourdough.toml
+++ b/byo-eks/components/0-configmap-sourdough.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "sourdough"
 
 manifest = "./manifests/sourdough-configmap.yaml"
+max_auto_retries = 5

--- a/byo-llm-openui/components/0-tf-cluster.toml
+++ b/byo-llm-openui/components/0-tf-cluster.toml
@@ -2,6 +2,7 @@
 name              = "cluster"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/byo-llm-openui/components/1-tf-certificate.toml
+++ b/byo-llm-openui/components/1-tf-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/byo-llm-openui/components/2-tf-service.toml
+++ b/byo-llm-openui/components/2-tf-service.toml
@@ -2,6 +2,7 @@
 name              = "open_webui"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/byo-llm-openui/components/3-tf-alb.toml
+++ b/byo-llm-openui/components/3-tf-alb.toml
@@ -2,6 +2,7 @@
 name              = "alb"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/clickhouse-tailscale/components/1-karpenter-nodepools.toml
+++ b/clickhouse-tailscale/components/1-karpenter-nodepools.toml
@@ -3,6 +3,7 @@ name           = "karpenter_nodepools"
 type           = "helm_chart"
 chart_name     = "karpenter-nodepools"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/clickhouse-tailscale/components/1-storage_class.toml
+++ b/clickhouse-tailscale/components/1-storage_class.toml
@@ -24,3 +24,4 @@ provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 """
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/2-crd-clickhouse_operator.toml
+++ b/clickhouse-tailscale/components/2-crd-clickhouse_operator.toml
@@ -6,6 +6,7 @@ namespace      = "kube-system"
 storage_driver = "configmap"
 
 dependencies   = ["storage_class", "crd_tailscale_operator"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "Altinity/clickhouse-operator"

--- a/clickhouse-tailscale/components/2-crd-tailscale_operator.toml
+++ b/clickhouse-tailscale/components/2-crd-tailscale_operator.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "tailscale"
 
 manifest = "./manifests/tailscale_operator.yaml"
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/2-km-tailscale_proxy.toml
+++ b/clickhouse-tailscale/components/2-km-tailscale_proxy.toml
@@ -6,3 +6,4 @@ namespace = "tailscale"
 dependencies = ["crd_tailscale_operator"]
 
 manifest = "./manifests/tailscale_proxy.yaml"
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/3-km-clickhouse_keeper.toml
+++ b/clickhouse-tailscale/components/3-km-clickhouse_keeper.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["crd_clickhouse_operator", "karpenter_nodepools", "tailscale_proxy"]
 
 manifest = "./manifests/clickhouse_keeper.yaml"
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/4-km-clickhouse_cluster.toml
+++ b/clickhouse-tailscale/components/4-km-clickhouse_cluster.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["clickhouse_keeper"]
 
 manifest = "./manifests/clickhouse_cluster.yaml"
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/4-km-clickhouse_ingress.toml
+++ b/clickhouse-tailscale/components/4-km-clickhouse_ingress.toml
@@ -5,3 +5,4 @@ namespace = "clickhouse"
 
 dependencies = ["clickhouse_service", "tailscale_proxy"]
 manifest = "./manifests/clickhouse_ingress.yaml"
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/4-km-clickhouse_service.toml
+++ b/clickhouse-tailscale/components/4-km-clickhouse_service.toml
@@ -5,3 +5,4 @@ namespace = "clickhouse"
 
 dependencies = ["clickhouse_cluster"]
 manifest = "./manifests/clickhouse_service.yaml"
+max_auto_retries = 5

--- a/clickhouse-tailscale/components/5-km-ch_ui.toml
+++ b/clickhouse-tailscale/components/5-km-ch_ui.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["clickhouse_ingress", "crd_tailscale_operator"]
 
 manifest  = "./manifests/ch_ui.yaml"
+max_auto_retries = 5

--- a/clickhouse/components/1-certificate.toml
+++ b/clickhouse/components/1-certificate.toml
@@ -3,6 +3,7 @@ name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 drift_schedule    = "*/45 * * * *"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/clickhouse/components/1-karpenter-nodepools.toml
+++ b/clickhouse/components/1-karpenter-nodepools.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "karpenter-nodepools"
 storage_driver = "configmap"
 drift_schedule = "17 * * * *"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/clickhouse/components/1-storage_class.toml
+++ b/clickhouse/components/1-storage_class.toml
@@ -25,3 +25,4 @@ provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 """
+max_auto_retries = 5

--- a/clickhouse/components/2-crd-clickhouse_operator.toml
+++ b/clickhouse/components/2-crd-clickhouse_operator.toml
@@ -6,6 +6,7 @@ namespace      = "kube-system"
 storage_driver = "configmap"
 
 dependencies   = ["storage_class"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "Altinity/clickhouse-operator"

--- a/clickhouse/components/3-km-clickhouse_keeper.toml
+++ b/clickhouse/components/3-km-clickhouse_keeper.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["crd_clickhouse_operator", "karpenter_nodepools"]
 
 manifest = "./manifests/clickhouse_keeper.yaml"
+max_auto_retries = 5

--- a/clickhouse/components/4-km-clickhouse_cluster.toml
+++ b/clickhouse/components/4-km-clickhouse_cluster.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["clickhouse_keeper"]
 
 manifest = "./manifests/clickhouse_cluster.yaml"
+max_auto_retries = 5

--- a/clickhouse/components/4-km-clickhouse_ingress.toml
+++ b/clickhouse/components/4-km-clickhouse_ingress.toml
@@ -5,3 +5,4 @@ namespace = "clickhouse"
 
 dependencies = ["clickhouse_service"]
 manifest = "./manifests/clickhouse_ingress.yaml"
+max_auto_retries = 5

--- a/clickhouse/components/4-km-clickhouse_service.toml
+++ b/clickhouse/components/4-km-clickhouse_service.toml
@@ -5,3 +5,4 @@ namespace = "clickhouse"
 
 dependencies = ["clickhouse_cluster", "certificate"]
 manifest = "./manifests/clickhouse_service.yaml"
+max_auto_retries = 5

--- a/clickhouse/components/5-km-ch_ui.toml
+++ b/clickhouse/components/5-km-ch_ui.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["clickhouse_cluster", "certificate"]
 
 manifest  = "./manifests/ch_ui.yaml"
+max_auto_retries = 5

--- a/cockroachdb/components/1-karpenter-nodepools.toml
+++ b/cockroachdb/components/1-karpenter-nodepools.toml
@@ -3,6 +3,7 @@ name           = "karpenter_nodepools"
 type           = "helm_chart"
 chart_name     = "karpenter-nodepools"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/cockroachdb/components/1-storage_class.toml
+++ b/cockroachdb/components/1-storage_class.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "default"
 
 manifest = "./manifests/storage_class.yaml"
+max_auto_retries = 5

--- a/cockroachdb/components/2-crd-cockroach-operator.toml
+++ b/cockroachdb/components/2-crd-cockroach-operator.toml
@@ -4,3 +4,4 @@ type         = "kubernetes_manifest"
 namespace    = "cockroach-operator-system"
 manifest     = "https://raw.githubusercontent.com/cockroachdb/cockroach-operator/v2.18.2/install/crds.yaml"
 dependencies = ["karpenter_nodepools"]
+max_auto_retries = 5

--- a/cockroachdb/components/2-crd-tailscale_operator.toml
+++ b/cockroachdb/components/2-crd-tailscale_operator.toml
@@ -6,3 +6,4 @@ namespace = "tailscale"
 dependencies = ["img_tailscale_operator"]
 
 manifest = "./manifests/tailscale_operator.yaml"
+max_auto_retries = 5

--- a/cockroachdb/components/2-km-tailscale_proxy.toml
+++ b/cockroachdb/components/2-km-tailscale_proxy.toml
@@ -4,3 +4,4 @@ type         = "kubernetes_manifest"
 namespace    = "tailscale"
 dependencies = ["crd_tailscale_operator"]
 manifest     = "./manifests/tailscale_proxy.yaml"
+max_auto_retries = 5

--- a/cockroachdb/components/3-km-cockroach-operator.toml
+++ b/cockroachdb/components/3-km-cockroach-operator.toml
@@ -4,3 +4,4 @@ type         = "kubernetes_manifest"
 namespace    = "cockroach-operator-system"
 manifest     = "./manifests/cockroach-operator.yaml"
 dependencies = ["cockroach_operator_crds"]
+max_auto_retries = 5

--- a/cockroachdb/components/4-tf-role-delegation.toml
+++ b/cockroachdb/components/4-tf-role-delegation.toml
@@ -2,6 +2,7 @@
 name              = "role_delegation"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/cockroachdb/components/5-km-cockroach-cluster.toml
+++ b/cockroachdb/components/5-km-cockroach-cluster.toml
@@ -4,3 +4,4 @@ type         = "kubernetes_manifest"
 namespace    = "cockroach"
 manifest     = "./manifests/cockroach-cluster.yaml"
 dependencies = ["cockroach_operator"]
+max_auto_retries = 5

--- a/cockroachdb/components/6-km-cockroach-client.toml
+++ b/cockroachdb/components/6-km-cockroach-client.toml
@@ -4,3 +4,4 @@ type         = "kubernetes_manifest"
 namespace    = "cockroach"
 manifest     = "./manifests/cockroach-client.yaml"
 dependencies = ["cockroach_cluster"]
+max_auto_retries = 5

--- a/coder/components/0-rds_subnet.toml
+++ b/coder/components/0-rds_subnet.toml
@@ -2,6 +2,7 @@
 name              = "rds_subnet"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/coder/components/1-rds_cluster_coder.toml
+++ b/coder/components/1-rds_cluster_coder.toml
@@ -3,6 +3,7 @@ name              = "rds_cluster_coder"
 type              = "terraform_module"
 terraform_version = "1.13.5"
 dependencies      = ["rds_subnet"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/coder/components/2-coder.toml
+++ b/coder/components/2-coder.toml
@@ -6,6 +6,7 @@ chart_name     = "coder"
 namespace      = "coder"
 storage_driver = "configmap"
 dependencies   = ["rds_cluster_coder"]
+max_auto_retries = 5
 
 [helm_repo]
 repo_url = "https://helm.coder.com/v2"

--- a/coder/components/3-certificate.toml
+++ b/coder/components/3-certificate.toml
@@ -3,6 +3,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/coder/components/4-alb.toml
+++ b/coder/components/4-alb.toml
@@ -5,6 +5,7 @@ type            = "helm_chart"
 chart_name      = "application-load-balancer"
 storage_driver  = "configmap"
 dependencies    = ["coder", "certificate"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/coder/components/5-kubelogstream.toml
+++ b/coder/components/5-kubelogstream.toml
@@ -4,6 +4,7 @@ chart_name     = "coder-logstream-kube"
 namespace      = "coder"
 storage_driver = "configmap"
 dependencies   = ["coder", "application_load_balancer"]
+max_auto_retries = 5
 
 [helm_repo]
 repo_url = "https://helm.coder.com/logstream-kube"

--- a/coder/components/6-observability.toml
+++ b/coder/components/6-observability.toml
@@ -4,6 +4,7 @@ chart_name     = "coder-observability"
 namespace      = "coder-observability"
 storage_driver = "configmap"
 dependencies   = ["coder", "application_load_balancer"]
+max_auto_retries = 5
 
 [helm_repo]
 repo_url = "https://helm.coder.com/observability"

--- a/data-ops/components/1-helm-temporal_init_db.toml
+++ b/data-ops/components/1-helm-temporal_init_db.toml
@@ -5,6 +5,7 @@ storage_driver = "configmap"
 namespace      = "temporal"
 
 dependencies   = ["karpenter_nodepools", "rds_cluster_temporal"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/data-ops/components/1-karpenter-nodepools.toml
+++ b/data-ops/components/1-karpenter-nodepools.toml
@@ -3,6 +3,7 @@ name           = "karpenter_nodepools"
 type           = "helm_chart"
 chart_name     = "karpenter-nodepools"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/data-ops/components/1-rds_cluster_temporal.toml
+++ b/data-ops/components/1-rds_cluster_temporal.toml
@@ -3,6 +3,7 @@ name              = "rds_cluster_temporal"
 type              = "terraform_module"
 terraform_version = "1.13.5"
 drift_schedule = "0 0 * * *"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/data-ops/components/1-rds_subnet.toml
+++ b/data-ops/components/1-rds_subnet.toml
@@ -2,6 +2,7 @@
 name              = "rds_subnet"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/data-ops/components/1-storage_class.toml
+++ b/data-ops/components/1-storage_class.toml
@@ -24,3 +24,4 @@ provisioner: kubernetes.io/aws-ebs
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 """
+max_auto_retries = 5

--- a/data-ops/components/2-crd-clickhouse_operator.toml
+++ b/data-ops/components/2-crd-clickhouse_operator.toml
@@ -6,6 +6,7 @@ namespace      = "kube-system"
 storage_driver = "configmap"
 
 dependencies   = ["storage_class", "crd_tailscale_operator"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "Altinity/clickhouse-operator"

--- a/data-ops/components/2-crd-tailscale_operator.toml
+++ b/data-ops/components/2-crd-tailscale_operator.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "tailscale"
 
 manifest = "./manifests/tailscale_operator.yaml"
+max_auto_retries = 5

--- a/data-ops/components/2-datadog_operator.toml
+++ b/data-ops/components/2-datadog_operator.toml
@@ -1,6 +1,7 @@
 name              = "datadog_operator"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/data-ops/components/2-helm-temporal.toml
+++ b/data-ops/components/2-helm-temporal.toml
@@ -5,6 +5,7 @@ storage_driver = "configmap"
 namespace      = "temporal"
 
 dependencies   = ["karpenter_nodepools", "rds_cluster_temporal", "temporal_init_db"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "temporalio/helm-charts"

--- a/data-ops/components/2-km-datadog_agent.toml
+++ b/data-ops/components/2-km-datadog_agent.toml
@@ -6,3 +6,4 @@ namespace = "datadog"
 dependencies = ["datadog_operator"]
 
 manifest = "./manifests/datadog_agent.yaml"
+max_auto_retries = 5

--- a/data-ops/components/2-km-tailscale_proxy.toml
+++ b/data-ops/components/2-km-tailscale_proxy.toml
@@ -6,3 +6,4 @@ namespace = "tailscale"
 dependencies = ["crd_tailscale_operator"]
 
 manifest = "./manifests/tailscale_proxy.yaml"
+max_auto_retries = 5

--- a/data-ops/components/3-km-clickhouse_keeper.toml
+++ b/data-ops/components/3-km-clickhouse_keeper.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["crd_clickhouse_operator", "karpenter_nodepools", "tailscale_proxy"]
 
 manifest = "./manifests/clickhouse_keeper.yaml"
+max_auto_retries = 5

--- a/data-ops/components/4-km-clickhouse_cluster.toml
+++ b/data-ops/components/4-km-clickhouse_cluster.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["clickhouse_keeper"]
 
 manifest = "./manifests/clickhouse_cluster.yaml"
+max_auto_retries = 5

--- a/data-ops/components/4-km-clickhouse_ingress.toml
+++ b/data-ops/components/4-km-clickhouse_ingress.toml
@@ -5,3 +5,4 @@ namespace = "clickhouse"
 
 dependencies = ["clickhouse_service", "tailscale_proxy"]
 manifest = "./manifests/clickhouse_ingress.yaml"
+max_auto_retries = 5

--- a/data-ops/components/4-km-clickhouse_service.toml
+++ b/data-ops/components/4-km-clickhouse_service.toml
@@ -5,3 +5,4 @@ namespace = "clickhouse"
 
 dependencies = ["clickhouse_cluster"]
 manifest = "./manifests/clickhouse_service.yaml"
+max_auto_retries = 5

--- a/data-ops/components/4-km-temporal_ingress.toml
+++ b/data-ops/components/4-km-temporal_ingress.toml
@@ -5,3 +5,4 @@ namespace = "temporal"
 
 dependencies = ["temporal"]
 manifest = "./manifests/temporal_ingress.yaml"
+max_auto_retries = 5

--- a/data-ops/components/5-km-ch_ui.toml
+++ b/data-ops/components/5-km-ch_ui.toml
@@ -6,3 +6,4 @@ namespace = "clickhouse"
 dependencies = ["clickhouse_ingress", "crd_tailscale_operator"]
 
 manifest  = "./manifests/ch_ui.yaml"
+max_auto_retries = 5

--- a/data-ops/components/5-km-temporal-ai-agent.toml
+++ b/data-ops/components/5-km-temporal-ai-agent.toml
@@ -6,3 +6,4 @@ namespace = "temporal-ai-agent"
 dependencies = ["temporal"]
 
 manifest  = "./manifests/temporal_ai_agent.yaml"
+max_auto_retries = 5

--- a/datadog-operator/components/0-datadog_operator.toml
+++ b/datadog-operator/components/0-datadog_operator.toml
@@ -1,6 +1,7 @@
 name              = "datadog_operator"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/datadog-operator/components/1-km-datadog_agent.toml
+++ b/datadog-operator/components/1-km-datadog_agent.toml
@@ -6,3 +6,4 @@ namespace = "datadog"
 dependencies = ["datadog_operator"]
 
 manifest = "./manifests/datadog_agent.yaml"
+max_auto_retries = 5

--- a/dynamic-roles-kitchen-sink/components/alb.toml
+++ b/dynamic-roles-kitchen-sink/components/alb.toml
@@ -4,6 +4,7 @@ name         = "application_load_balancer"
 type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["whoami"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/dynamic-roles-kitchen-sink/components/certificate.toml
+++ b/dynamic-roles-kitchen-sink/components/certificate.toml
@@ -3,6 +3,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/dynamic-roles-kitchen-sink/components/whoami.toml
+++ b/dynamic-roles-kitchen-sink/components/whoami.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "whoami"
 namespace      = "whoami"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-breakglass/components/0-tf-cluster.toml
+++ b/ecs-breakglass/components/0-tf-cluster.toml
@@ -2,6 +2,7 @@
 name              = "cluster"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-breakglass/components/1-tf-certificate.toml
+++ b/ecs-breakglass/components/1-tf-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/ecs-breakglass/components/2-tf-service.toml
+++ b/ecs-breakglass/components/2-tf-service.toml
@@ -2,6 +2,7 @@
 name              = "whoami"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-breakglass/components/3-tf-alb.toml
+++ b/ecs-breakglass/components/3-tf-alb.toml
@@ -2,6 +2,7 @@
 name              = "alb"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-breakglass/components/4-tf-role-delegation.toml
+++ b/ecs-breakglass/components/4-tf-role-delegation.toml
@@ -2,6 +2,7 @@
 name              = "role_delegation"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-simple/components/0-tf-cluster.toml
+++ b/ecs-simple/components/0-tf-cluster.toml
@@ -2,6 +2,7 @@
 name              = "cluster"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-simple/components/1-tf-certificate.toml
+++ b/ecs-simple/components/1-tf-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/ecs-simple/components/2-tf-service.toml
+++ b/ecs-simple/components/2-tf-service.toml
@@ -2,6 +2,7 @@
 name              = "whoami"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/ecs-simple/components/3-tf-alb.toml
+++ b/ecs-simple/components/3-tf-alb.toml
@@ -2,6 +2,7 @@
 name              = "alb"
 type              = "terraform_module"
 terraform_version = "1.13.5"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/eks-karpenter-image-cache/components/image_cache.toml
+++ b/eks-karpenter-image-cache/components/image_cache.toml
@@ -2,6 +2,7 @@
 name              = "image_cache"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/eks-karpenter-image-cache/components/node_class.toml
+++ b/eks-karpenter-image-cache/components/node_class.toml
@@ -5,3 +5,4 @@ namespace    = "kube-system"
 dependencies = ["image_cache"]
 
 manifest = "./manifests/ec2nodeclass.yaml"
+max_auto_retries = 5

--- a/eks-karpenter-image-cache/components/node_pool.toml
+++ b/eks-karpenter-image-cache/components/node_pool.toml
@@ -5,3 +5,4 @@ namespace    = "kube-system"
 dependencies = ["node_class"]
 
 manifest = "./manifests/nodepool.yaml"
+max_auto_retries = 5

--- a/eks-karpenter-image-cache/components/whoami.toml
+++ b/eks-karpenter-image-cache/components/whoami.toml
@@ -5,6 +5,7 @@ chart_name     = "whoami"
 namespace      = "whoami"
 storage_driver = "configmap"
 dependencies   = ["node_pool"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/eks-simple-auto/components/alb.toml
+++ b/eks-simple-auto/components/alb.toml
@@ -3,6 +3,7 @@ name         = "application_load_balancer"
 chart_name   = "application-load-balancer"
 namespace    = "whoami"
 dependencies = ["whoami"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/eks-simple-auto/components/certificate.toml
+++ b/eks-simple-auto/components/certificate.toml
@@ -1,6 +1,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/eks-simple-auto/components/whoami.toml
+++ b/eks-simple-auto/components/whoami.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "whoami"
 
 manifest = "./manifests/whoami.yaml"
+max_auto_retries = 5

--- a/eks-simple-kustomize/components/1-kustomize-app.toml
+++ b/eks-simple-kustomize/components/1-kustomize-app.toml
@@ -2,6 +2,7 @@ name = "kustomizeapp"
 type = "kubernetes_manifest"
 
 namespace = "{{.nuon.install.id}}"
+max_auto_retries = 5
 
 [public_repo]
 directory = "."

--- a/eks-simple/components/alb.toml
+++ b/eks-simple/components/alb.toml
@@ -4,6 +4,7 @@ name         = "application_load_balancer"
 type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["whoami"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/eks-simple/components/certificate.toml
+++ b/eks-simple/components/certificate.toml
@@ -3,6 +3,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/eks-simple/components/whoami.toml
+++ b/eks-simple/components/whoami.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "whoami"
 namespace      = "whoami"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-cloud-function/components/0-docker-image.toml
+++ b/gcp-cloud-function/components/0-docker-image.toml
@@ -2,6 +2,7 @@ name = "docker_image"
 type = "docker_build"
 
 dockerfile = "Dockerfile"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-cloud-function/components/1-tf-cloud-function.toml
+++ b/gcp-cloud-function/components/1-tf-cloud-function.toml
@@ -2,6 +2,7 @@ name              = "cloud_function"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["docker_image"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-cloud-run/components/1-tf-cloud-run.toml
+++ b/gcp-cloud-run/components/1-tf-cloud-run.toml
@@ -2,6 +2,7 @@ name              = "cloud_run"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["container_image"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-cloud-run/components/2-pulumi-gcs-bucket.toml
+++ b/gcp-cloud-run/components/2-pulumi-gcs-bucket.toml
@@ -2,6 +2,7 @@
 name    = "pulumi_gcs_bucket"
 type    = "pulumi"
 runtime = "go"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-cloud-run/components/3-pulumi-gcs-object.toml
+++ b/gcp-cloud-run/components/3-pulumi-gcs-object.toml
@@ -3,6 +3,7 @@ name         = "pulumi_gcs_object"
 type         = "pulumi"
 runtime      = "go"
 dependencies = ["pulumi_gcs_bucket"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-gcs-static-site/components/0-tf-gcs-bucket.toml
+++ b/gcp-gcs-static-site/components/0-tf-gcs-bucket.toml
@@ -1,6 +1,7 @@
 name              = "gcs_bucket"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-gcs-static-site/components/1-tf-upload-site.toml
+++ b/gcp-gcs-static-site/components/1-tf-upload-site.toml
@@ -2,6 +2,7 @@ name              = "upload_site"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["gcs_bucket"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gcp-gcs-static-site/components/2-tf-cdn.toml
+++ b/gcp-gcs-static-site/components/2-tf-cdn.toml
@@ -2,6 +2,7 @@ name              = "cdn"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["gcs_bucket"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-actions/components/0-helm-nginx.toml
+++ b/gke-actions/components/0-helm-nginx.toml
@@ -4,6 +4,7 @@ chart_name     = "nginx"
 namespace      = "nginx-demo"
 storage_driver = "configmap"
 drift_schedule = "0 */6 * * *"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-secrets/components/0-helm-app.toml
+++ b/gke-secrets/components/0-helm-app.toml
@@ -3,6 +3,7 @@ type           = "helm_chart"
 chart_name     = "secrets-demo"
 namespace      = "secrets-demo"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-simple/components/certificate.toml
+++ b/gke-simple/components/certificate.toml
@@ -1,6 +1,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-simple/components/ingress.toml
+++ b/gke-simple/components/ingress.toml
@@ -3,6 +3,7 @@ type           = "helm_chart"
 chart_name     = "gke-ingress"
 dependencies   = ["whoami", "certificate"]
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-simple/components/whoami.toml
+++ b/gke-simple/components/whoami.toml
@@ -3,6 +3,7 @@ type           = "helm_chart"
 chart_name     = "whoami"
 namespace      = "whoami"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-workload-identity/components/0-tf-service-account.toml
+++ b/gke-workload-identity/components/0-tf-service-account.toml
@@ -1,6 +1,7 @@
 name              = "service_account"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-workload-identity/components/1-tf-gcs-bucket.toml
+++ b/gke-workload-identity/components/1-tf-gcs-bucket.toml
@@ -2,6 +2,7 @@ name              = "gcs_bucket"
 type              = "terraform_module"
 terraform_version = "1.11.3"
 dependencies      = ["service_account"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/gke-workload-identity/components/2-helm-app.toml
+++ b/gke-workload-identity/components/2-helm-app.toml
@@ -4,6 +4,7 @@ chart_name     = "wi-demo"
 namespace      = "wi-demo"
 storage_driver = "configmap"
 dependencies   = ["service_account", "gcs_bucket"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/grafana/components/0-rds_subnet.toml
+++ b/grafana/components/0-rds_subnet.toml
@@ -2,6 +2,7 @@
 name              = "rds_subnet"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/grafana/components/1-rds_cluster_exampledb.toml
+++ b/grafana/components/1-rds_cluster_exampledb.toml
@@ -5,6 +5,7 @@ terraform_version = "1.11.3"
 dependencies      = ["rds_cluster_grafana"]
 
 drift_schedule = "0 0 * * *"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/grafana/components/1-rds_cluster_grafana.toml
+++ b/grafana/components/1-rds_cluster_grafana.toml
@@ -4,6 +4,7 @@ type              = "terraform_module"
 terraform_version = "1.11.3"
 
 drift_schedule = "0 0 * * *"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/grafana/components/2-exampledb-secrets.toml
+++ b/grafana/components/2-exampledb-secrets.toml
@@ -13,3 +13,4 @@ kind: Namespace
 metadata:
   name: exampledb
 """
+max_auto_retries = 5

--- a/grafana/components/2-grafana-secrets.toml
+++ b/grafana/components/2-grafana-secrets.toml
@@ -14,3 +14,4 @@ kind: Namespace
 metadata:
   name: grafana
 """
+max_auto_retries = 5

--- a/grafana/components/3-postgres-exporter.toml
+++ b/grafana/components/3-postgres-exporter.toml
@@ -5,6 +5,7 @@ chart_name     = "prometheus-postgres-exporter"
 namespace      = "exampledb"
 storage_driver = "configmap"
 dependencies   = ["rds_cluster_exampledb"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "prometheus-community/helm-charts"

--- a/grafana/components/4-prometheus.toml
+++ b/grafana/components/4-prometheus.toml
@@ -5,6 +5,7 @@ chart_name     = "prometheus"
 namespace      = "grafana"
 storage_driver = "configmap"
 dependencies   = ["postgres_exporter"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "prometheus-community/helm-charts"

--- a/grafana/components/5-grafana.toml
+++ b/grafana/components/5-grafana.toml
@@ -5,6 +5,7 @@ chart_name     = "grafana"
 namespace      = "grafana"
 storage_driver = "configmap"
 dependencies   = ["prometheus", "grafana_secrets", "exampledb_secrets", "rds_cluster_grafana", "rds_cluster_exampledb"]
+max_auto_retries = 5
 
 [helm_repo]
 repo_url = "https://grafana.github.io/helm-charts"

--- a/grafana/components/6-certificate.toml
+++ b/grafana/components/6-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/grafana/components/7-alb.toml
+++ b/grafana/components/7-alb.toml
@@ -3,6 +3,7 @@ name         = "application_load_balancer"
 type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["certificate", "grafana"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/httpbin/components/1-ec2.toml
+++ b/httpbin/components/1-ec2.toml
@@ -2,6 +2,7 @@
 name              = "ec2"
 type              = "terraform_module"
 terraform_version = "1.11.4"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/mattermost/components/1-postgres-db.toml
+++ b/mattermost/components/1-postgres-db.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "postgresql"
 namespace      = "mattermost"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/mattermost/components/1-s3_buckets.toml
+++ b/mattermost/components/1-s3_buckets.toml
@@ -2,6 +2,7 @@
 name              = "s3_buckets"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/mattermost/components/2-mattermost-operator.toml
+++ b/mattermost/components/2-mattermost-operator.toml
@@ -5,6 +5,7 @@ chart_name     = "mattermost-operator"
 namespace      = "mattermost-operator"
 storage_driver = "configmap"
 dependencies   = ["postgres_db"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "mattermost/mattermost-helm"

--- a/mattermost/components/3-mattermost-db-secret.toml
+++ b/mattermost/components/3-mattermost-db-secret.toml
@@ -16,3 +16,4 @@ stringData:
   DB_CONNECTION_STRING: "postgres://mattermost:mattermost@postgresql.mattermost.svc.cluster.local:5432/mattermost?sslmode=disable&connect_timeout=10"
   DB_CONNECTION_CHECK_URL: "postgres://mattermost:mattermost@postgresql.mattermost.svc.cluster.local:5432/postgres?connect_timeout=10"
 """
+max_auto_retries = 5

--- a/mattermost/components/3-mattermost-s3-secret.toml
+++ b/mattermost/components/3-mattermost-s3-secret.toml
@@ -16,3 +16,4 @@
     accesskey: ""
     secretkey: ""
   """
+  max_auto_retries = 5

--- a/mattermost/components/4-mattermost-installation.toml
+++ b/mattermost/components/4-mattermost-installation.toml
@@ -35,3 +35,4 @@ spec:
 # https://github.com/mattermost/mattermost-operator/blob/master/docs/examples/mattermost_full.yaml
 # https://github.com/mattermost/mattermost-operator/blob/master/config/crd/bases/installation.mattermost.com_mattermosts.yaml
 # https://github.com/mattermost/mattermost/releases/
+max_auto_retries = 5

--- a/mattermost/components/5-certificate.toml
+++ b/mattermost/components/5-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/mattermost/components/6-alb.toml
+++ b/mattermost/components/6-alb.toml
@@ -3,6 +3,7 @@ name         = "application_load_balancer"
 type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["mattermost_manifest_installation","certificate"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/mattermost/components/7-mattermost-manifest-service.toml
+++ b/mattermost/components/7-mattermost-manifest-service.toml
@@ -21,3 +21,4 @@ spec:
       targetPort: 8065
       protocol: TCP
 """
+max_auto_retries = 5

--- a/n8n/components/1-s3-buckets.toml
+++ b/n8n/components/1-s3-buckets.toml
@@ -2,6 +2,7 @@
 name              = "s3_buckets"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/n8n/components/2-postgres-db.toml
+++ b/n8n/components/2-postgres-db.toml
@@ -5,6 +5,7 @@ chart_name     = "postgresql"
 namespace      = "n8n"
 storage_driver = "configmap"
 timeout        = "15m"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/n8n/components/3-redis.toml
+++ b/n8n/components/3-redis.toml
@@ -6,6 +6,7 @@ namespace      = "n8n"
 storage_driver = "configmap"
 dependencies   = []
 timeout        = "10m"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/n8n/components/4-certificate.toml
+++ b/n8n/components/4-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/n8n/components/5-n8n-main.toml
+++ b/n8n/components/5-n8n-main.toml
@@ -6,6 +6,7 @@ namespace      = "n8n"
 storage_driver = "configmap"
 dependencies   = ["postgres_db", "redis", "ollama_server"]
 timeout        = "15m"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/n8n/components/6-n8n-workers.toml
+++ b/n8n/components/6-n8n-workers.toml
@@ -6,6 +6,7 @@ namespace      = "n8n"
 storage_driver = "configmap"
 dependencies   = ["n8n_main", "ollama_server"]
 timeout        = "10m"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/n8n/components/7-ingress.toml
+++ b/n8n/components/7-ingress.toml
@@ -38,3 +38,4 @@ spec:
                 port:
                   number: 5678
 """
+max_auto_retries = 5

--- a/n8n/components/8-ollama-server.toml
+++ b/n8n/components/8-ollama-server.toml
@@ -6,6 +6,7 @@ namespace      = "n8n"
 storage_driver = "configmap"
 dependencies   = []
 timeout        = "15m"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/operation-roles-demo/components/alb.toml
+++ b/operation-roles-demo/components/alb.toml
@@ -3,6 +3,7 @@ name           = "application_load_balancer"
 type           = "helm_chart"
 chart_name     = "application-load-balancer"
 dependencies   = ["whoami", "certificate"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/operation-roles-demo/components/certificate.toml
+++ b/operation-roles-demo/components/certificate.toml
@@ -3,6 +3,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/operation-roles-demo/components/whoami.toml
+++ b/operation-roles-demo/components/whoami.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "whoami"
 namespace      = "whoami"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/penpot/components/alb.toml
+++ b/penpot/components/alb.toml
@@ -4,6 +4,7 @@ name         = "application_load_balancer"
 type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["penpot"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/penpot/components/certificate.toml
+++ b/penpot/components/certificate.toml
@@ -3,6 +3,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/penpot/components/penpot.toml
+++ b/penpot/components/penpot.toml
@@ -4,6 +4,7 @@ type           = "helm_chart"
 chart_name     = "penpot"
 namespace      = "penpot"
 storage_driver = "configmap"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "penpot/penpot-helm"

--- a/policies-demo/components/0-certificate.toml
+++ b/policies-demo/components/0-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/policies-demo/components/1-whoami.toml
+++ b/policies-demo/components/1-whoami.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "whoami"
 
 manifest = "./manifests/whoami.yaml"
+max_auto_retries = 5

--- a/policies-demo/components/2-alb.toml
+++ b/policies-demo/components/2-alb.toml
@@ -4,6 +4,7 @@ type         = "helm_chart"
 chart_name   = "application-load-balancer"
 namespace    = "whoami"
 dependencies = ["whoami"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/components"

--- a/policies-demo/components/3-s3-bucket.toml
+++ b/policies-demo/components/3-s3-bucket.toml
@@ -2,6 +2,7 @@
 name              = "s3_bucket"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "matt-zach-s/policies-demo"

--- a/policies-demo/components/4-database.toml
+++ b/policies-demo/components/4-database.toml
@@ -2,6 +2,7 @@
 name              = "demo_database"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "matt-zach-s/policies-demo"

--- a/policies-demo/components/5-whoami-kube-system.toml
+++ b/policies-demo/components/5-whoami-kube-system.toml
@@ -4,3 +4,4 @@ type      = "kubernetes_manifest"
 namespace = "kube-system"
 
 manifest = "./manifests/whoami-kube-system.yaml"
+max_auto_retries = 5

--- a/twenty/components/0-default-storage-class.toml
+++ b/twenty/components/0-default-storage-class.toml
@@ -19,3 +19,4 @@ parameters:
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 """
+max_auto_retries = 5

--- a/twenty/components/1-twenty-pv-db.toml
+++ b/twenty/components/1-twenty-pv-db.toml
@@ -21,3 +21,4 @@ spec:
     path: /tmp/data/twentycrm/db
   persistentVolumeReclaimPolicy: Retain
 """
+max_auto_retries = 5

--- a/twenty/components/10-twenty-deployment-redis.toml
+++ b/twenty/components/10-twenty-deployment-redis.toml
@@ -50,3 +50,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 """
+max_auto_retries = 5

--- a/twenty/components/11-twenty-deployment-worker.toml
+++ b/twenty/components/11-twenty-deployment-worker.toml
@@ -80,3 +80,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 """
+max_auto_retries = 5

--- a/twenty/components/13-twenty-deployment-server.toml
+++ b/twenty/components/13-twenty-deployment-server.toml
@@ -104,3 +104,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 """
+max_auto_retries = 5

--- a/twenty/components/14-twenty-service-db.toml
+++ b/twenty/components/14-twenty-service-db.toml
@@ -25,3 +25,4 @@ spec:
       timeoutSeconds: 10800
   type: ClusterIP
 """
+max_auto_retries = 5

--- a/twenty/components/15-twenty-service-redis.toml
+++ b/twenty/components/15-twenty-service-redis.toml
@@ -25,3 +25,4 @@ spec:
       timeoutSeconds: 10800
   type: ClusterIP
 """
+max_auto_retries = 5

--- a/twenty/components/16-twenty-service-server.toml
+++ b/twenty/components/16-twenty-service-server.toml
@@ -26,3 +26,4 @@ spec:
       timeoutSeconds: 10800
   type: ClusterIP
 """
+max_auto_retries = 5

--- a/twenty/components/2-twenty-pv-server.toml
+++ b/twenty/components/2-twenty-pv-server.toml
@@ -21,3 +21,4 @@ spec:
     path: /tmp/data/twentycrm/server
   persistentVolumeReclaimPolicy: Retain
 """
+max_auto_retries = 5

--- a/twenty/components/21-certificate.toml
+++ b/twenty/components/21-certificate.toml
@@ -2,6 +2,7 @@
 name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.11.3"
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/twenty/components/22-alb.toml
+++ b/twenty/components/22-alb.toml
@@ -3,6 +3,7 @@ name         = "application_load_balancer"
 type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["certificate", "twenty_deployment_server"]
+max_auto_retries = 5
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/twenty/components/3-twenty-pv-docker-data.toml
+++ b/twenty/components/3-twenty-pv-docker-data.toml
@@ -21,3 +21,4 @@ spec:
     path: /tmp/data/twentycrm/docker-data
   persistentVolumeReclaimPolicy: Retain
 """
+max_auto_retries = 5

--- a/twenty/components/4-twenty-pvc-db.toml
+++ b/twenty/components/4-twenty-pvc-db.toml
@@ -20,3 +20,4 @@ spec:
     requests:
       storage: 10Gi
 """
+max_auto_retries = 5

--- a/twenty/components/5-twenty-pvc-server.toml
+++ b/twenty/components/5-twenty-pvc-server.toml
@@ -20,3 +20,4 @@ spec:
     requests:
       storage: 10Gi
 """
+max_auto_retries = 5

--- a/twenty/components/6-twenty-secret.toml
+++ b/twenty/components/6-twenty-secret.toml
@@ -19,3 +19,4 @@ stringData:
   fileToken: "{{ .nuon.inputs.inputs.file_token_secret }}"
   appSecret: "{{ .nuon.inputs.inputs.app_secret }}"
 """
+max_auto_retries = 5

--- a/twenty/components/7-twenty-pvc-docker-data.toml
+++ b/twenty/components/7-twenty-pvc-docker-data.toml
@@ -20,3 +20,4 @@ spec:
     requests:
       storage: 10Gi
 """
+max_auto_retries = 5

--- a/twenty/components/8-twenty-deployment-db.toml
+++ b/twenty/components/8-twenty-deployment-db.toml
@@ -65,3 +65,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
 """
+max_auto_retries = 5

--- a/twenty/components/9-twenty-db-init.toml
+++ b/twenty/components/9-twenty-db-init.toml
@@ -38,3 +38,4 @@ spec:
         - -c
         - CREATE DATABASE "default";
 """
+max_auto_retries = 5

--- a/uptime-monitor/components/0-api-image.toml
+++ b/uptime-monitor/components/0-api-image.toml
@@ -42,6 +42,7 @@ dockerfile = "Dockerfile"
 # REPOSITORY CONFIGURATION
 # -----------------------------------------------------------------------------
 # Using a public repository (no authentication required):
+max_auto_retries = 5
 [public_repo]
 repo      = "nuonco/uptime-monitor"
 directory = "api"

--- a/uptime-monitor/components/0-ui-image.toml
+++ b/uptime-monitor/components/0-ui-image.toml
@@ -42,6 +42,7 @@ dockerfile = "Dockerfile"
 # REPOSITORY CONFIGURATION
 # -----------------------------------------------------------------------------
 # Using a public repository (no authentication required):
+max_auto_retries = 5
 [public_repo]
 repo      = "nuonco/uptime-monitor"
 directory = "ui"

--- a/uptime-monitor/components/1-irsa.toml
+++ b/uptime-monitor/components/1-irsa.toml
@@ -49,6 +49,7 @@ dependencies = ["s3", "rds"]
 # -----------------------------------------------------------------------------
 # REPOSITORY CONFIGURATION
 # -----------------------------------------------------------------------------
+max_auto_retries = 5
 [public_repo]
 repo      = "nuonco/example-app-configs"
 directory = "uptime-monitor/components/1-irsa"

--- a/uptime-monitor/components/1-rds.toml
+++ b/uptime-monitor/components/1-rds.toml
@@ -58,6 +58,7 @@ terraform_version = "1.14.3"
 # -----------------------------------------------------------------------------
 # REPOSITORY CONFIGURATION
 # -----------------------------------------------------------------------------
+max_auto_retries = 5
 [public_repo]
 repo      = "nuonco/example-app-configs"
 directory = "uptime-monitor/components/1-rds"

--- a/uptime-monitor/components/1-s3.toml
+++ b/uptime-monitor/components/1-s3.toml
@@ -52,6 +52,7 @@ terraform_version = "1.14.3"
 # -----------------------------------------------------------------------------
 # Points to the Terraform module directory.
 # Here we reference the same repo this config lives in.
+max_auto_retries = 5
 [public_repo]
 repo      = "nuonco/example-app-configs"
 directory = "uptime-monitor/components/1-s3"

--- a/uptime-monitor/components/2-api.toml
+++ b/uptime-monitor/components/2-api.toml
@@ -76,3 +76,4 @@ manifest = "./2-api/manifest.yaml"
 # repo      = "nuonco/uptime-monitor"
 # directory = "nuon/uptime-monitor/components/2-api/kustomize"
 # branch    = "main"
+max_auto_retries = 5

--- a/uptime-monitor/components/2-ui.toml
+++ b/uptime-monitor/components/2-ui.toml
@@ -49,3 +49,4 @@ manifest = "./2-ui/manifest.yaml"
 # Useful for the drift demo - manually scale or modify the deployment via
 # kubectl, then trigger a drift scan to see Nuon detect the changes.
 # drift_schedule = "*/10 * * * *"  # Every 10 minutes
+max_auto_retries = 5

--- a/uptime-monitor/components/3-headlamp.toml
+++ b/uptime-monitor/components/3-headlamp.toml
@@ -46,6 +46,7 @@ namespace = "default"
 # -----------------------------------------------------------------------------
 # REPOSITORY CONFIGURATION
 # -----------------------------------------------------------------------------
+max_auto_retries = 5
 [helm_repo]
 repo_url = "https://kubernetes-sigs.github.io/headlamp"
 chart    = "headlamp"

--- a/uptime-monitor/components/4-alb.toml
+++ b/uptime-monitor/components/4-alb.toml
@@ -42,3 +42,4 @@ dependencies = ["ui", "headlamp"]
 
 # Path to manifest file containing the Ingress resource.
 manifest = "./4-alb/manifest.yaml"
+max_auto_retries = 5


### PR DESCRIPTION
Adds component-level auto-retry config across 186 component TOMLs spanning 35 app configs. Field is supported on helm_chart, terraform_module, docker_build, kubernetes_manifest, and pulumi component types per nuonco/nuon@b382af4b6. Skipped 29 container_image components (type unsupported).

When a deploy or teardown apply fails, Nuon will re-plan + re-apply the component up to 5 times before failing.