### PR TITLE
fix(cde): add-ssh-key action input + yellow status clarification

### DIFF
--- a/cde/README.md
+++ b/cde/README.md
@@ -17,7 +17,7 @@ A personal cloud development environment running in your AWS account. Connect vi
 {{ if .nuon.actions.populated -}}
 {{- $vsCodeEnabled := .nuon.install.inputs.install_vscode_web -}}
 {{- $vmStopped := eq (dig "status" "" .nuon.actions.workflows.healthcheck_ec2) "error" -}}
-*Checks run every 5 minutes. Last results:*
+*Checks run every 5 minutes. Last results (🟡 means a check is currently running — refresh in a moment):*
 
 {{ with .nuon.actions.workflows.healthcheck_ec2 -}}
 **EC2 VM ({{ $.nuon.install.inputs.instance_type }}):** {{ if eq .status "finished" }}🟢 running{{ else if eq .status "error" }}🔴 stopped{{ else }}🟡 unknown{{ end }}

--- a/cde/actions/add-ssh-key.toml
+++ b/cde/actions/add-ssh-key.toml
@@ -32,7 +32,7 @@ done
 
 [ "$STATUS" = "Online" ] || { echo "SSM agent did not come online in time"; exit 1; }
 
-NEW_SSH_KEY="{{ .action.inputs.ssh_public_key }}"
+NEW_SSH_KEY="$SSH_PUBLIC_KEY"
 KEY_B64=$(echo "$NEW_SSH_KEY" | base64 -w 0)
 
 cat > /tmp/add-ssh-key.sh << 'SCRIPT'
@@ -103,6 +103,7 @@ done
 """
 
 [steps.env_vars]
-INSTANCE_ID = "{{.nuon.components.ec2.outputs.instance_id}}"
-REGION      = "{{.nuon.sandbox.outputs.account.region}}"
-SSH_USER    = "{{.nuon.components.ec2.outputs.ssh_user}}"
+INSTANCE_ID    = "{{.nuon.components.ec2.outputs.instance_id}}"
+REGION         = "{{.nuon.sandbox.outputs.account.region}}"
+SSH_USER       = "{{.nuon.components.ec2.outputs.ssh_user}}"
+SSH_PUBLIC_KEY = ""


### PR DESCRIPTION
## Summary

- Adds `SSH_PUBLIC_KEY` as an editable env var in the `add-ssh-key` action dialog — previously the key was only referenced via template interpolation with no corresponding field, causing users to paste into `SSH_USER` by mistake
- Updates README status section intro to explain that 🟡 means a check is currently running, not an unknown/broken state