### PR TITLE
chore(cde): pin runner init_script_url to aws-v0.1.0 tag

### DIFF
--- a/cde/runner.toml
+++ b/cde/runner.toml
@@ -1,4 +1,4 @@
 # runner
 runner_type     = "aws"
 helm_driver     = "configmap"
-init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/heads/main/scripts/aws/init-mng-v2.sh"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/tags/aws-v0.1.0/scripts/aws/init-mng.sh"


### PR DESCRIPTION
Bring cde in line with the other 20 AWS app configs (commits b67b587, 4377261). cde was merged in parallel with the init-script pinning sweep and missed it, leaving it pointing at refs/heads/main/scripts/aws/init-mng-v2.sh instead of the released tag.