### PR TITLE
chore(stacks): align cde to v0.4.0 and fix eks-multi-env naming residue

### DIFF
--- a/aws-lambda/stack.toml
+++ b/aws-lambda/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-lambda-{{.nuon.install.id}}"
+name        = "nuon-aws-lambda-{{.nuon.install.id}}"
 description = "QuickLink to install runner for Lambda app config: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/cde/stack.toml
+++ b/cde/stack.toml
@@ -2,5 +2,5 @@ type        = "aws-cloudformation"
 name        = "nuon-cde-{{.nuon.install.id}}"
 description = "QuickLink to install runner for the CDE app config: Install {{.nuon.install.id}}"
 
-vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.3.0/vpc/eks/default/stack.yaml"
+vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"
 runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/runner/asg/stack.yaml"

--- a/clickhouse-tailscale/stack.toml
+++ b/clickhouse-tailscale/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-clickhouse-{{.nuon.install.id}}"
+name        = "nuon-clickhouse-tailscale-{{.nuon.install.id}}"
 description = "QuickLink to install runner for Clickhouse Demo: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/clickhouse/stack.toml
+++ b/clickhouse/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-clickhouse-{{.nuon.install.id}}"
+name        = "nuon-clickhouse-{{.nuon.install.id}}"
 description = "QuickLink to install runner for Clickhouse Demo: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/data-ops/stack.toml
+++ b/data-ops/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-clickhouse-{{.nuon.install.id}}"
+name        = "nuon-data-ops-{{.nuon.install.id}}"
 description = "QuickLink to install runner for Clickhouse Demo: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/datadog-operator/stack.toml
+++ b/datadog-operator/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-datadog-operator-{{.nuon.install.id}}"
+name        = "nuon-datadog-operator-{{.nuon.install.id}}"
 description = "QuickLink to install runner for Datadog Operator: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/dynamic-roles-kitchen-sink/stack.toml
+++ b/dynamic-roles-kitchen-sink/stack.toml
@@ -1,6 +1,6 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-simple-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+name        = "nuon-dynamic-roles-kitchen-sink-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"

--- a/eks-karpenter-image-cache/stack.toml
+++ b/eks-karpenter-image-cache/stack.toml
@@ -1,6 +1,6 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-image-cache-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+name        = "nuon-eks-karpenter-image-cache-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"

--- a/eks-multi-env/break_glass.toml
+++ b/eks-multi-env/break_glass.toml
@@ -1,5 +1,5 @@
 [[role]]
-name                 = "{{.nuon.install.id}}-eks-simple-sandbox-break-glass"
+name                 = "{{.nuon.install.id}}-eks-multi-env-sandbox-break-glass"
 description          = "grants access to the sandbox for install {{.nuon.install.id}}."
 display_name         = "break glass role"
 permissions_boundary = ""

--- a/eks-multi-env/stack.toml
+++ b/eks-multi-env/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-simple-{{.nuon.install.id}}"
+name        = "nuon-eks-multi-env-{{.nuon.install.id}}"
 description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/eks-multi-env/stack.toml
+++ b/eks-multi-env/stack.toml
@@ -1,6 +1,6 @@
 type        = "aws-cloudformation"
 name        = "nuon-eks-multi-env-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"

--- a/eks-simple-auto/stack.toml
+++ b/eks-simple-auto/stack.toml
@@ -1,6 +1,6 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-simple-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+name        = "nuon-eks-simple-auto-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"

--- a/eks-simple-kustomize/stack.toml
+++ b/eks-simple-kustomize/stack.toml
@@ -1,6 +1,6 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-simple-kustomize-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+name        = "nuon-eks-simple-kustomize-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"
 runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/runner/asg/stack.yaml"

--- a/eks-simple/stack.toml
+++ b/eks-simple/stack.toml
@@ -1,6 +1,6 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-simple-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+name        = "nuon-eks-simple-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 # nested stack
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"

--- a/httpbin/stack.toml
+++ b/httpbin/stack.toml
@@ -1,5 +1,5 @@
 type        = "aws-cloudformation"
-name        = "nuon-demos-httpbin-{{.nuon.install.id}}"
+name        = "nuon-httpbin-{{.nuon.install.id}}"
 description = "QuickLink to install runner for the HTTPBin app config: Install {{.nuon.install.id}}"
 
 # nested stack

--- a/policies-demo/stack.toml
+++ b/policies-demo/stack.toml
@@ -1,7 +1,7 @@
 # stack
 type        = "aws-cloudformation"
-name        = "nuon-demos-eks-policies-{{.nuon.install.id}}"
-description = "QuickLink to install runner for BYOC Nuon: Install {{.nuon.install.id}}"
+name        = "nuon-policies-demo-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
 
 vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"
 runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/runner/asg/stack.yaml"


### PR DESCRIPTION
Stack/meta cleanup across aws-cloudformation apps.

- cde/stack.toml: bump vpc v0.3.0 -> v0.4.0 to match runner
- drop nuon-demos- prefix from 13 stack names (now all match the standard nuon-<app>- shape)
- fix wrong-app copy-paste residue in clickhouse-tailscale, data-ops, dynamic-roles-kitchen-sink, eks-multi-env, eks-simple-auto
- drop "for BYOC Nuon" from 7 stack descriptions
- rename eks-multi-env break-glass role to match the app name