### PR TITLE
feat(gke-simple): kustomize component to exercise state interpolation

### DIFF
--- a/gke-simple/components/kustomize-demo.toml
+++ b/gke-simple/components/kustomize-demo.toml
@@ -1,0 +1,14 @@
+name             = "kustomizedemo"
+type             = "kubernetes_manifest"
+namespace        = "kustomize-demo"
+max_auto_retries = 5
+
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "gke-simple/src/components/kustomize-demo"
+branch    = "ht/kustomize-state-demo"
+
+[kustomize]
+path        = "."
+patches     = []
+enable_helm = false

--- a/gke-simple/src/components/kustomize-demo/configmap.yaml
+++ b/gke-simple/src/components/kustomize-demo/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: install-info
+  annotations:
+    nuon.co/rendered-install-id: "{{.nuon.install.id}}"
+data:
+  install_id: "{{.nuon.install.id}}"
+  install_name: "{{.nuon.install.name}}"
+  app_id: "{{.nuon.app.id}}"
+  project_id: "{{.nuon.install_stack.outputs.project_id}}"

--- a/gke-simple/src/components/kustomize-demo/deployment.yaml
+++ b/gke-simple/src/components/kustomize-demo/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kustomize-demo
+  labels:
+    nuon-install-id: "{{.nuon.install.id}}"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kustomize-demo
+  template:
+    metadata:
+      labels:
+        app: kustomize-demo
+        nuon-install-id: "{{.nuon.install.id}}"
+    spec:
+      containers:
+        - name: hello
+          image: nginxdemos/hello:plain-text
+          ports:
+            - containerPort: 80
+          env:
+            - name: NUON_INSTALL_ID
+              value: "{{.nuon.install.id}}"
+            - name: NUON_INSTALL_NAME
+              value: "{{.nuon.install.name}}"
+            - name: NUON_APP_ID
+              value: "{{.nuon.app.id}}"

--- a/gke-simple/src/components/kustomize-demo/kustomization.yaml
+++ b/gke-simple/src/components/kustomize-demo/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - deployment.yaml
+
+labels:
+  - pairs:
+      app: kustomize-demo
+    includeSelectors: true

--- a/gke-simple/src/components/kustomize-demo/kustomization.yaml
+++ b/gke-simple/src/components/kustomize-demo/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - namespace.yaml
   - configmap.yaml
   - deployment.yaml
 

--- a/gke-simple/src/components/kustomize-demo/namespace.yaml
+++ b/gke-simple/src/components/kustomize-demo/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kustomize-demo


### PR DESCRIPTION

## What's new in gke-simple

Kustomize overlay in this repo, deploys a Namespace, a ConfigMap, and a small Deployment into `kustomize-demo`, and references `install.id`, `install.name`, `app.id`, and `install_stack.outputs.project_id` from inside the Kustomize tree.
