### PR TITLE
forgejo-gcp + gcp-cloud-run: pulumi sandbox

### DIFF
--- a/forgejo-gcp/README.md
+++ b/forgejo-gcp/README.md
@@ -2,6 +2,11 @@
 > **Experimental** — this sample app config is a work in progress and is not
 > guaranteed to deploy successfully. Use it as a reference only.
 
+> [!IMPORTANT]
+> This app uses a **Pulumi-typed sandbox** (`sandbox.type = "pulumi"`, see `sandbox.toml`).
+> Your org must have the **`pulumi-sandbox`** feature flag enabled before installing —
+> otherwise the sandbox config sync is rejected. Enable it in org settings (or ask Nuon).
+
 <center>
 <h1>Forgejo (GCP)</h1>
 

--- a/forgejo-gcp/sandbox.toml
+++ b/forgejo-gcp/sandbox.toml
@@ -1,19 +1,15 @@
-terraform_version = "1.11.3"
+type    = "pulumi"
+runtime = "go"
 
 [public_repo]
 directory = "."
-repo      = "nuonco/gcp-gke-sandbox"
+repo      = "nuonco/gcp-gke-sandbox-pulumi"
 branch    = "main"
 
-[vars]
-nuon_id                = "{{ .nuon.install.id }}"
-project_id             = "{{ .nuon.install_stack.outputs.project_id }}"
-region                 = "{{ .nuon.install_stack.outputs.region }}"
-cluster_name           = "n-{{ .nuon.install.id }}"
-enable_nuon_dns        = "true"
-public_root_domain    = "{{ .nuon.install.id }}.{{ .nuon.inputs.inputs.domain }}"
-internal_root_domain  = "internal.{{ .nuon.install.id }}.{{ .nuon.inputs.inputs.domain }}"
-gke_node_pool_sa_email = "{{ .nuon.install_stack.outputs.gke_node_pool_sa_email }}"
-
-[[var_file]]
-contents = "./sandbox.tfvars"
+# nuon_id, project_id, region, network and subnetwork are injected automatically
+# for GCP runners; only app-specific config is set here.
+[pulumi_config]
+"nuon:cluster_name"         = "n-{{ .nuon.install.id }}"
+"nuon:enable_nuon_dns"      = "true"
+"nuon:public_root_domain"   = "{{ .nuon.install.id }}.{{ .nuon.inputs.inputs.domain }}"
+"nuon:internal_root_domain" = "internal.{{ .nuon.install.id }}.{{ .nuon.inputs.inputs.domain }}"

--- a/forgejo-gcp/src/components/pulumi-postgres/main.go
+++ b/forgejo-gcp/src/components/pulumi-postgres/main.go
@@ -44,6 +44,9 @@ func main() {
 			Network:               pulumi.String(network),
 			Service:               pulumi.String("servicenetworking.googleapis.com"),
 			ReservedPeeringRanges: pulumi.StringArray{psaRange.Name},
+			// A peering connection is per-network and may already exist from a
+			// prior partial run; update it instead of failing the create.
+			UpdateOnCreationFail: pulumi.Bool(true),
 		})
 		if err != nil {
 			return fmt.Errorf("psa connection: %w", err)
@@ -89,9 +92,10 @@ func main() {
 		}
 
 		db, err := sql.NewDatabase(ctx, "forgejo", &sql.DatabaseArgs{
-			Name:     pulumi.String("forgejo"),
-			Project:  pulumi.String(projectID),
-			Instance: instance.Name,
+			Name:           pulumi.String("forgejo"),
+			Project:        pulumi.String(projectID),
+			Instance:       instance.Name,
+			DeletionPolicy: pulumi.String("ABANDON"),
 		})
 		if err != nil {
 			return fmt.Errorf("database: %w", err)
@@ -102,6 +106,9 @@ func main() {
 			Project:  pulumi.String(projectID),
 			Instance: instance.Name,
 			Password: password.Result,
+			// Postgres won't DROP a role that owns objects; abandon on destroy
+			// (the instance teardown removes the user anyway).
+			DeletionPolicy: pulumi.String("ABANDON"),
 		})
 		if err != nil {
 			return fmt.Errorf("user: %w", err)

--- a/gcp-cloud-run/README.md
+++ b/gcp-cloud-run/README.md
@@ -1,3 +1,8 @@
+> [!IMPORTANT]
+> This app uses a **Pulumi-typed sandbox** (`sandbox.type = "pulumi"`, see `sandbox.toml`).
+> Your org must have the **`pulumi-sandbox`** feature flag enabled before installing —
+> otherwise the sandbox config sync is rejected. Enable it in org settings (or ask Nuon).
+
 <center>
 <h1>GCP Cloud Run</h1>
 

--- a/gcp-cloud-run/sandbox.toml
+++ b/gcp-cloud-run/sandbox.toml
@@ -1,9 +1,10 @@
-terraform_version = "1.11.3"
+type    = "pulumi"
+runtime = "go"
 
 [public_repo]
 directory = "."
-repo      = "nuonco/gcp-min-sandbox"
+repo      = "nuonco/gcp-min-sandbox-pulumi"
 branch    = "main"
 
-[vars]
-enable_nuon_dns = "false"
+[pulumi_config]
+"nuon:enable_nuon_dns" = "false"


### PR DESCRIPTION
Switch both apps to the pulumi sandbox; postgres user/db ABANDON + PSA update-on-creation-fail; readme notes that the pulumi-sandbox org feature must be enabled.