### PR TITLE
feat: add 4 runbooks to eks-simple

### DIFF
--- a/eks-simple/runbooks/deploy_all.md
+++ b/eks-simple/runbooks/deploy_all.md
@@ -1,0 +1,9 @@
+Deploys all EKS components in order.
+
+**Components**
+
+| Component | Description |
+|---|---|
+| `certificate` | ACM certificate for domain |
+| `whoami` | Whoami Helm chart deployment |
+| `application_load_balancer` | Application Load Balancer |

--- a/eks-simple/runbooks/deploy_all.toml
+++ b/eks-simple/runbooks/deploy_all.toml
@@ -1,0 +1,18 @@
+name        = "deploy_all"
+description = "Deploys all EKS components in order."
+readme      = "./runbooks/deploy_all.md"
+
+[[steps]]
+name           = "Deploy certificate"
+type           = "deploy"
+component_name = "certificate"
+
+[[steps]]
+name           = "Deploy whoami"
+type           = "deploy"
+component_name = "whoami"
+
+[[steps]]
+name           = "Deploy ALB"
+type           = "deploy"
+component_name = "application_load_balancer"

--- a/eks-simple/runbooks/deploy_and_verify.md
+++ b/eks-simple/runbooks/deploy_and_verify.md
@@ -1,0 +1,19 @@
+Deploys all EKS components in order, then runs verification checks to ensure everything is working correctly.
+
+**Components**
+
+| Component | Description |
+|---|---|
+| `certificate` | ACM certificate for domain |
+| `whoami` | Whoami Helm chart deployment |
+| `application_load_balancer` | Application Load Balancer |
+
+**Actions**
+
+| Action | Description |
+|---|---|
+| `certificate_status` | Checks ACM certificate status |
+| `deployments_status` | Gets Kubernetes deployment status |
+| `alb` | Gets ALB details (load balancer, upstreams, security groups, ACL) |
+| `alb_healthcheck` | Runs ALB health check |
+| `whoami` | Tests the whoami endpoint (end-to-end check) |

--- a/eks-simple/runbooks/deploy_and_verify.toml
+++ b/eks-simple/runbooks/deploy_and_verify.toml
@@ -1,0 +1,43 @@
+name        = "deploy_and_verify"
+description = "Deploys all components, then runs verification checks."
+readme      = "./runbooks/deploy_and_verify.md"
+
+[[steps]]
+name           = "Deploy certificate"
+type           = "deploy"
+component_name = "certificate"
+
+[[steps]]
+name           = "Deploy whoami"
+type           = "deploy"
+component_name = "whoami"
+
+[[steps]]
+name           = "Deploy ALB"
+type           = "deploy"
+component_name = "application_load_balancer"
+
+[[steps]]
+name        = "Certificate status"
+type        = "action"
+action_name = "certificate_status"
+
+[[steps]]
+name        = "Deployment status"
+type        = "action"
+action_name = "deployments_status"
+
+[[steps]]
+name        = "ALB details"
+type        = "action"
+action_name = "alb"
+
+[[steps]]
+name        = "ALB healthcheck"
+type        = "action"
+action_name = "alb_healthcheck"
+
+[[steps]]
+name        = "Whoami endpoint"
+type        = "action"
+action_name = "whoami"

--- a/eks-simple/runbooks/operational_actions.md
+++ b/eks-simple/runbooks/operational_actions.md
@@ -1,0 +1,8 @@
+Runs operational actions that modify resources. Use with caution as these actions change the state of the application.
+
+**Actions**
+
+| Action | Description |
+|---|---|
+| `simple_demonstration` | Creates secrets in the cluster |
+| `deployment_restart` | Restarts the whoami deployment |

--- a/eks-simple/runbooks/operational_actions.toml
+++ b/eks-simple/runbooks/operational_actions.toml
@@ -1,0 +1,13 @@
+name        = "operational_actions"
+description = "Runs operational actions that modify resources: creates secrets and restarts deployment."
+readme      = "./runbooks/operational_actions.md"
+
+[[steps]]
+name        = "Simple demonstration"
+type        = "action"
+action_name = "simple_demonstration"
+
+[[steps]]
+name        = "Restart deployment"
+type        = "action"
+action_name = "deployment_restart"

--- a/eks-simple/runbooks/verify_status.md
+++ b/eks-simple/runbooks/verify_status.md
@@ -1,0 +1,11 @@
+Runs verification and status checks for the EKS application without modifying any resources.
+
+**Actions**
+
+| Action | Description |
+|---|---|
+| `certificate_status` | Checks ACM certificate status |
+| `deployments_status` | Gets Kubernetes deployment status |
+| `alb` | Gets ALB details (load balancer, upstreams, security groups, ACL) |
+| `alb_healthcheck` | Runs ALB health check |
+| `whoami` | Tests the whoami endpoint (end-to-end check) |

--- a/eks-simple/runbooks/verify_status.toml
+++ b/eks-simple/runbooks/verify_status.toml
@@ -1,0 +1,28 @@
+name        = "verify_status"
+description = "Runs verification and status checks for certificate, deployments, ALB, and endpoint."
+readme      = "./runbooks/verify_status.md"
+
+[[steps]]
+name        = "Certificate status"
+type        = "action"
+action_name = "certificate_status"
+
+[[steps]]
+name        = "Deployment status"
+type        = "action"
+action_name = "deployments_status"
+
+[[steps]]
+name        = "ALB details"
+type        = "action"
+action_name = "alb"
+
+[[steps]]
+name        = "ALB healthcheck"
+type        = "action"
+action_name = "alb_healthcheck"
+
+[[steps]]
+name        = "Whoami endpoint"
+type        = "action"
+action_name = "whoami"


### PR DESCRIPTION
add 4 runbooks to eks-simple

- verify_status: run read-only verification checks
- operational_actions: run state-changing actions
- deploy_all: deploy all components
- deploy_and_verify: deploy + verify
