### PR TITLE
feat: add 4 actions and 4 runbooks to ecs-simple

### DIFF
--- a/ecs-simple/actions/certificate_status.toml
+++ b/ecs-simple/actions/certificate_status.toml
@@ -1,0 +1,29 @@
+# action
+name    = "certificate_status"
+timeout = "30s"
+enable_kube_config = false
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "describe"
+inline_contents = """
+#!/usr/bin/env sh
+set -e
+
+echo "Checking certificate status..."
+
+export AWS_PAGER=""
+aws acm describe-certificate \
+  --certificate-arn ${CERTIFICATE_ARN} \
+  --region ${REGION} \
+  --output table
+
+echo ""
+echo "✓ Certificate status check complete"
+"""
+
+[steps.env_vars]
+CERTIFICATE_ARN = "{{.nuon.components.certificate.outputs.arn}}"
+REGION = "{{.nuon.install.sandbox.outputs.account.region}}"

--- a/ecs-simple/actions/curl_endpoint.toml
+++ b/ecs-simple/actions/curl_endpoint.toml
@@ -1,0 +1,22 @@
+# action
+name    = "curl_endpoint"
+timeout = "30s"
+enable_kube_config = false
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "curl_service"
+inline_contents = """
+#!/usr/bin/env sh
+set -e
+
+echo "Curling service endpoint..."
+curl -s ${SERVICE_URL}
+echo ""
+echo "✓ Endpoint check complete"
+"""
+
+[steps.env_vars]
+SERVICE_URL = "{{.nuon.components.alb.outputs.url}}"

--- a/ecs-simple/actions/restart_service.toml
+++ b/ecs-simple/actions/restart_service.toml
@@ -1,0 +1,57 @@
+# action
+name    = "restart_service"
+timeout = "45s"
+enable_kube_config = false
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "restart"
+inline_contents = """
+#!/usr/bin/env sh
+set -e
+
+echo "Forcing new deployment for ECS service..."
+
+# Force new deployment
+aws ecs update-service \
+  --cluster ${CLUSTER_NAME} \
+  --service ${SERVICE_NAME} \
+  --force-new-deployment \
+  --region ${REGION} \
+  --output table
+
+echo ""
+echo "✓ Service restart initiated"
+"""
+
+[steps.env_vars]
+CLUSTER_NAME = "{{.nuon.components.cluster.outputs.cluster_name}}"
+SERVICE_NAME = "{{.nuon.components.whoami.outputs.service_name}}"
+REGION = "{{.nuon.install.sandbox.outputs.account.region}}"
+
+[[steps]]
+name = "status"
+inline_contents = """
+#!/usr/bin/env sh
+set -e
+
+echo "Checking service status after restart..."
+sleep 5
+
+aws ecs describe-services \
+  --cluster ${CLUSTER_NAME} \
+  --services ${SERVICE_NAME} \
+  --region ${REGION} \
+  --query 'services[0].[serviceName,status,runningCount,desiredCount,deployments[0].rolloutState]' \
+  --output table
+
+echo ""
+echo "✓ Status check complete"
+"""
+
+[steps.env_vars]
+CLUSTER_NAME = "{{.nuon.components.cluster.outputs.cluster_name}}"
+SERVICE_NAME = "{{.nuon.components.whoami.outputs.service_name}}"
+REGION = "{{.nuon.install.sandbox.outputs.account.region}}"

--- a/ecs-simple/actions/service_status.toml
+++ b/ecs-simple/actions/service_status.toml
@@ -1,0 +1,31 @@
+# action
+name    = "service_status"
+timeout = "30s"
+enable_kube_config = false
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "check_service"
+inline_contents = """
+#!/usr/bin/env sh
+set -e
+
+echo "Checking ECS service status..."
+
+# Get ECS service details
+aws ecs describe-services \
+  --cluster ${CLUSTER_NAME} \
+  --services ${SERVICE_NAME} \
+  --region ${REGION} \
+  --output table
+
+echo ""
+echo "✓ Service status check complete"
+"""
+
+[steps.env_vars]
+CLUSTER_NAME = "{{.nuon.components.cluster.outputs.cluster_name}}"
+SERVICE_NAME = "{{.nuon.components.whoami.outputs.service_name}}"
+REGION = "{{.nuon.install.sandbox.outputs.account.region}}"

--- a/ecs-simple/runbooks/deploy_all.md
+++ b/ecs-simple/runbooks/deploy_all.md
@@ -1,0 +1,11 @@
+Deploys all ECS components in order.
+
+**Components**
+
+| Component | Description |
+|---|---|
+| `img_whoami` | Container image |
+| `cluster` | ECS cluster |
+| `certificate` | ACM certificate |
+| `whoami` | ECS service |
+| `alb` | Application Load Balancer |

--- a/ecs-simple/runbooks/deploy_all.toml
+++ b/ecs-simple/runbooks/deploy_all.toml
@@ -1,0 +1,28 @@
+name        = "deploy_all"
+description = "Deploys all ECS components in order."
+readme      = "./runbooks/deploy_all.md"
+
+[[steps]]
+name           = "Deploy container image"
+type           = "deploy"
+component_name = "img_whoami"
+
+[[steps]]
+name           = "Deploy ECS cluster"
+type           = "deploy"
+component_name = "cluster"
+
+[[steps]]
+name           = "Deploy certificate"
+type           = "deploy"
+component_name = "certificate"
+
+[[steps]]
+name           = "Deploy ECS service"
+type           = "deploy"
+component_name = "whoami"
+
+[[steps]]
+name           = "Deploy ALB"
+type           = "deploy"
+component_name = "alb"

--- a/ecs-simple/runbooks/deploy_and_verify.md
+++ b/ecs-simple/runbooks/deploy_and_verify.md
@@ -1,0 +1,19 @@
+Deploys all ECS components in order, then runs verification checks to ensure everything is working correctly.
+
+**Components**
+
+| Component | Description |
+|---|---|
+| `img_whoami` | Container image |
+| `cluster` | ECS cluster |
+| `certificate` | ACM certificate |
+| `whoami` | ECS service |
+| `alb` | Application Load Balancer |
+
+**Actions**
+
+| Action | Description |
+|---|---|
+| `service_status` | Gets ECS service status and deployment details |
+| `certificate_status` | Checks ACM certificate status |
+| `curl_endpoint` | Tests the service endpoint (end-to-end check) |

--- a/ecs-simple/runbooks/deploy_and_verify.toml
+++ b/ecs-simple/runbooks/deploy_and_verify.toml
@@ -1,0 +1,43 @@
+name        = "deploy_and_verify"
+description = "Deploys all components, then runs verification checks."
+readme      = "./runbooks/deploy_and_verify.md"
+
+[[steps]]
+name           = "Deploy container image"
+type           = "deploy"
+component_name = "img_whoami"
+
+[[steps]]
+name           = "Deploy ECS cluster"
+type           = "deploy"
+component_name = "cluster"
+
+[[steps]]
+name           = "Deploy certificate"
+type           = "deploy"
+component_name = "certificate"
+
+[[steps]]
+name           = "Deploy ECS service"
+type           = "deploy"
+component_name = "whoami"
+
+[[steps]]
+name           = "Deploy ALB"
+type           = "deploy"
+component_name = "alb"
+
+[[steps]]
+name        = "Service status"
+type        = "action"
+action_name = "service_status"
+
+[[steps]]
+name        = "Certificate status"
+type        = "action"
+action_name = "certificate_status"
+
+[[steps]]
+name        = "Curl endpoint"
+type        = "action"
+action_name = "curl_endpoint"

--- a/ecs-simple/runbooks/deploy_verify_and_restart.md
+++ b/ecs-simple/runbooks/deploy_verify_and_restart.md
@@ -1,0 +1,20 @@
+Deploys all ECS components, verifies everything is working, then forces a service restart with zero downtime.
+
+**Components**
+
+| Component | Description |
+|---|---|
+| `img_whoami` | Container image |
+| `cluster` | ECS cluster |
+| `certificate` | ACM certificate |
+| `whoami` | ECS service |
+| `alb` | Application Load Balancer |
+
+**Actions**
+
+| Action | Description |
+|---|---|
+| `service_status` | Gets ECS service status and deployment details |
+| `certificate_status` | Checks ACM certificate status |
+| `curl_endpoint` | Tests the service endpoint (end-to-end check) |
+| `restart_service` | Forces a new deployment (rolling restart) |

--- a/ecs-simple/runbooks/deploy_verify_and_restart.toml
+++ b/ecs-simple/runbooks/deploy_verify_and_restart.toml
@@ -1,0 +1,48 @@
+name        = "deploy_verify_and_restart"
+description = "Deploys all components, runs verification checks, then restarts the service."
+readme      = "./runbooks/deploy_verify_and_restart.md"
+
+[[steps]]
+name           = "Deploy container image"
+type           = "deploy"
+component_name = "img_whoami"
+
+[[steps]]
+name           = "Deploy ECS cluster"
+type           = "deploy"
+component_name = "cluster"
+
+[[steps]]
+name           = "Deploy certificate"
+type           = "deploy"
+component_name = "certificate"
+
+[[steps]]
+name           = "Deploy ECS service"
+type           = "deploy"
+component_name = "whoami"
+
+[[steps]]
+name           = "Deploy ALB"
+type           = "deploy"
+component_name = "alb"
+
+[[steps]]
+name        = "Service status"
+type        = "action"
+action_name = "service_status"
+
+[[steps]]
+name        = "Certificate status"
+type        = "action"
+action_name = "certificate_status"
+
+[[steps]]
+name        = "Curl endpoint"
+type        = "action"
+action_name = "curl_endpoint"
+
+[[steps]]
+name        = "Restart service"
+type        = "action"
+action_name = "restart_service"

--- a/ecs-simple/runbooks/verify_status.md
+++ b/ecs-simple/runbooks/verify_status.md
@@ -1,0 +1,9 @@
+Runs verification checks for the ECS application without modifying any resources.
+
+**Actions**
+
+| Action | Description |
+|---|---|
+| `service_status` | Gets ECS service status and deployment details |
+| `certificate_status` | Checks ACM certificate status |
+| `curl_endpoint` | Tests the service endpoint (end-to-end check) |

--- a/ecs-simple/runbooks/verify_status.toml
+++ b/ecs-simple/runbooks/verify_status.toml
@@ -1,0 +1,18 @@
+name        = "verify_status"
+description = "Runs verification checks for ECS service, certificate, and endpoint."
+readme      = "./runbooks/verify_status.md"
+
+[[steps]]
+name        = "Service status"
+type        = "action"
+action_name = "service_status"
+
+[[steps]]
+name        = "Certificate status"
+type        = "action"
+action_name = "certificate_status"
+
+[[steps]]
+name        = "Curl endpoint"
+type        = "action"
+action_name = "curl_endpoint"


### PR DESCRIPTION
add 4 actions and 4 runbooks to ecs-simple

Actions:
- service_status: check ECS service details
- certificate_status: check ACM certificate
- curl_endpoint: test endpoint
- restart_service: force new deployment

Runbooks:
- verify_status: run verification actions
- deploy_all: deploy all components
- deploy_and_verify: deploy + verify
- deploy_verify_and_restart: deploy + verify + restart
