### PR TITLE
ci: fix Sync Nuon App auth and add sync-all dispatch

### DIFF
--- a/.github/workflows/sync-app.yaml
+++ b/.github/workflows/sync-app.yaml
@@ -4,6 +4,32 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      sync_all:
+        description: Sync all apps (ignore changed-dir detection)
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      NUON_DEBUG:
+        description: NUON_DEBUG
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  NUON_DEBUG: "${{ github.event.inputs.NUON_DEBUG }}"
+  NUON_ORG_ID: orghrsmmlfozvjxraku0ubb4qq
 
 jobs:
   detect-changes:
@@ -19,11 +45,16 @@ jobs:
       - name: Get changed directories
         id: set-matrix
         run: |
-          # Get list of changed files
-          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          if [ "${{ github.event.inputs.sync_all }}" = "true" ]; then
+            # Manual dispatch: sync every app dir (exclude dotfiles, scripts, docs)
+            CHANGED_DIRS=$(find . -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -u | grep -v '^\.' | grep -vE '^(scripts|docs)$' || true)
+          else
+            # Get list of changed files
+            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
 
-          # Extract unique top-level directories (excluding .github)
-          CHANGED_DIRS=$(echo "$CHANGED_FILES" | cut -d'/' -f1 | sort -u | grep -v '^\.' | grep -v '^$' || true)
+            # Extract unique top-level directories (excluding dotfiles, scripts, docs)
+            CHANGED_DIRS=$(echo "$CHANGED_FILES" | cut -d'/' -f1 | sort -u | grep -v '^\.' | grep -v '^$' | grep -vE '^(scripts|docs)$' || true)
+          fi
 
           if [ -z "$CHANGED_DIRS" ]; then
             echo "No app directories changed"
@@ -41,15 +72,35 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    name: Push to Nuon
     strategy:
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for skip-sync label
+        id: check_label
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --search "${{ github.sha }}" --state merged --json number -q '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            LABELS=$(gh pr view "$PR_NUMBER" --json labels -q '.labels[].name')
+            if echo "$LABELS" | grep -q "skip-sync"; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "Skipping sync due to skip-sync label on PR #$PR_NUMBER"
+            fi
+          fi
+
+      - name: Install CLI
+        if: steps.check_label.outputs.skip != 'true'
+        run: ./scripts/install-cli.sh
 
       - name: Sync ${{ matrix.app }}
-        uses: nuonco/actions-nuon@v0.3.0
-        with:
-          org_id: ${{ secrets.NUON_ORG_ID }}
-          api_token: ${{ secrets.NUON_API_TOKEN }}
-          command: apps sync -d ${{ matrix.app }}
+        if: steps.check_label.outputs.skip != 'true'
+        working-directory: ${{ matrix.app }}
+        run: nuon apps sync .
+        env:
+          NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN }}

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+if [ "$NUON_DEBUG" = "true" ]
+then
+  set -x
+fi
+
+set -e
+set -o pipefail
+set -u
+
+BASE_URL=https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli
+NAME=nuon
+
+DIR=~/bin
+if [ ! -d "$DIR" ]; then
+  DIR=/usr/local/bin
+
+  # fall back to /usr/local/bin
+  if [ ! -d $DIR ]; then
+    # fall back to /bin
+    DIR=/bin
+  fi
+fi
+
+echo "Installing nuon cli into $DIR"
+
+echo "checking OS and Architecture..."
+set +e
+dpkg_path=$(which dpkg)
+set -e
+if [ "$dpkg_path" = "" ]
+then
+  ARCH=$(uname -m)
+else
+  ARCH=$(dpkg --print-architecture)
+fi
+
+if [ "$ARCH" = "x86_64" ]; then
+  ARCH=amd64
+fi
+
+OS=$(uname -s |  awk '{print tolower($0)}')
+echo "✅ using version ${OS}_${ARCH}..."
+
+echo "calculating latest version..."
+VERSION=$(curl -s $BASE_URL/latest.txt)
+echo "✅ using version ${VERSION}..."
+
+echo "fetching binary for ${OS} ${ARCH}..."
+curl -s -o $DIR/$NAME $BASE_URL/$VERSION/${NAME}_${OS}_${ARCH}
+echo "✅ fetching binary for ${OS} ${ARCH}..."
+
+echo "making binary executable..."
+chmod +x $DIR/$NAME
+echo "✅ nuon should be ready to use"


### PR DESCRIPTION
Mirrors byoc's working "Push to Nuon" pattern so the sync workflow actually authenticates.

## Why
Every recent `Sync Nuon App` run failed with `No API token configured` — the repo had no `NUON_API_TOKEN` secret, so the `actions-nuon` preflight aborted before syncing.

## Changes
- Drop `nuonco/actions-nuon` → byoc's direct `scripts/install-cli.sh` + `nuon apps sync .` with env-var auth (`NUON_ORG_ID`, `NUON_API_TOKEN`).
- Add `skip-sync` PR-label gate.
- Add `workflow_dispatch` `sync_all` input to sync every app dir.
- Keep the changed-dir matrix; exclude `scripts`/`docs`.
- `scripts/install-cli.sh`: byoc's CLI installer.

Org `orghrsmmlfozvjxraku0ubb4qq`; long-lived static token stored as repo secret `NUON_API_TOKEN` (verified against the org).