### PR TITLE
fix: add missing sandbox.tfvars for gke apps

### DIFF
--- a/coder-gcp/sandbox.tfvars
+++ b/coder-gcp/sandbox.tfvars
@@ -1,0 +1,1 @@
+additional_namespaces = ["coder", "coder-observability"]

--- a/gke-actions/sandbox.tfvars
+++ b/gke-actions/sandbox.tfvars
@@ -1,0 +1,1 @@
+additional_namespaces = ["nginx-demo"]

--- a/gke-secrets/sandbox.tfvars
+++ b/gke-secrets/sandbox.tfvars
@@ -1,0 +1,1 @@
+additional_namespaces = ["secrets-demo"]

--- a/gke-workload-identity/sandbox.tfvars
+++ b/gke-workload-identity/sandbox.tfvars
@@ -1,0 +1,1 @@
+additional_namespaces = ["wi-demo"]


### PR DESCRIPTION
## Why
`Push to Nuon` failed for these GKE apps with:
`unable to fetch file ./sandbox.tfvars ... no such file or directory`

Each app's `sandbox.toml` declares `[[var_file]] contents = "./sandbox.tfvars"` (gcp-gke-sandbox), but the file was missing.

## Fix
Add `sandbox.tfvars` with `additional_namespaces` for the namespaces each app deploys into:
- `coder-gcp` → `coder`, `coder-observability`
- `gke-actions` → `nginx-demo`
- `gke-secrets` → `secrets-demo`
- `gke-workload-identity` → `wi-demo`

All four verified with `nuon apps sync` against org `orghrsmmlfozvjxraku0ubb4qq` → `successfully synced`. (Force-added; `*.tfvars` is gitignored but these are tracked like the other apps' sandbox.tfvars.)