### PR TITLE
fix: correct readme path case in eks-karpenter-image-cache

### DIFF
--- a/eks-karpenter-image-cache/metadata.toml
+++ b/eks-karpenter-image-cache/metadata.toml
@@ -2,4 +2,4 @@ version = "v2"
 
 description = "EKS with Karpenter and pre-cached container images via EBS snapshots. Ideal for large images that would otherwise cause slow node scale-out."
 display_name = "EKS Karpenter Image Cache"
-readme       = "./readme.md"
+readme       = "./README.md"


### PR DESCRIPTION
## Why
`Push to Nuon` failed for `eks-karpenter-image-cache`:
`unable to fetch file ./readme.md ... no such file or directory`

`metadata.toml` referenced `./readme.md` but the file is `README.md`. Works on case-insensitive macOS, fails on the case-sensitive Linux runner.

## Fix
`readme = "./readme.md"` → `"./README.md"` (matches the convention used by other apps).

Verified with `nuon apps sync` against org `orghrsmmlfozvjxraku0ubb4qq` → `successfully synced`.