### PR TITLE
feat: add 4 policies to httpbin

### DIFF
--- a/httpbin/policies.toml
+++ b/httpbin/policies.toml
@@ -1,0 +1,23 @@
+# policies
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-vpc-cidr.rego"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-multi-az-subnets.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["ec2"]
+contents   = "./policies/pass-instance-tags.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["ec2"]
+contents   = "./policies/warn-public-security-group.rego"

--- a/httpbin/policies/pass-instance-tags.rego
+++ b/httpbin/policies/pass-instance-tags.rego
@@ -1,0 +1,19 @@
+package nuon
+
+# Pass when EC2 instance has proper required tags
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_instance"
+    resource.change.actions[_] in ["create", "update"]
+    tags := resource.change.after.tags
+    
+    # Check for required tags
+    tags["Name"]
+    tags["install.nuon.co/id"]
+    tags["component.nuon.co/name"]
+    
+    msg := sprintf(
+        "EC2 instance '%s' has all required tags (Name, install ID, component name)",
+        [resource.address],
+    )
+}

--- a/httpbin/policies/pass-multi-az-subnets.rego
+++ b/httpbin/policies/pass-multi-az-subnets.rego
@@ -1,0 +1,24 @@
+package nuon
+
+# Pass when subnets are distributed across multiple availability zones
+pass contains msg if {
+    subnet_resources := [resource | 
+        resource := input.plan.resource_changes[_]
+        resource.type == "aws_subnet"
+        resource.change.actions[_] in ["create", "update"]
+    ]
+    
+    # Get unique availability zones
+    azs := {az | 
+        subnet := subnet_resources[_]
+        az := subnet.change.after.availability_zone
+    }
+    
+    # Check if we have multiple AZs
+    count(azs) > 1
+    
+    msg := sprintf(
+        "Subnets are distributed across %d availability zones for high availability",
+        [count(azs)],
+    )
+}

--- a/httpbin/policies/pass-vpc-cidr.rego
+++ b/httpbin/policies/pass-vpc-cidr.rego
@@ -1,0 +1,14 @@
+package nuon
+
+# Pass when VPC uses a proper private CIDR block (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    startswith(cidr, "10.") or startswith(cidr, "172.") or startswith(cidr, "192.168.")
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}

--- a/httpbin/policies/pass-vpc-cidr.rego
+++ b/httpbin/policies/pass-vpc-cidr.rego
@@ -6,7 +6,38 @@ pass contains msg if {
     resource.type == "aws_vpc"
     resource.change.actions[_] in ["create", "update"]
     cidr := resource.change.after.cidr_block
-    startswith(cidr, "10.") or startswith(cidr, "172.") or startswith(cidr, "192.168.")
+    
+    # Check if CIDR starts with valid private range
+    startswith(cidr, "10.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "172.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "192.168.")
+    
     msg := sprintf(
         "VPC '%s' uses proper private CIDR block: %s",
         [resource.address, cidr],

--- a/httpbin/policies/warn-public-security-group.rego
+++ b/httpbin/policies/warn-public-security-group.rego
@@ -1,0 +1,17 @@
+package nuon
+
+# Warn when security group allows public access (0.0.0.0/0)
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_security_group"
+    resource.change.actions[_] in ["create", "update"]
+    
+    # Check for ingress rules with 0.0.0.0/0
+    some ingress in resource.change.after.ingress
+    "0.0.0.0/0" in ingress.cidr_blocks
+    
+    msg := sprintf(
+        "Security group '%s' allows public access (0.0.0.0/0) - ensure this is intentional for public-facing services",
+        [resource.address],
+    )
+}


### PR DESCRIPTION
add 4 policies to httpbin

Sandbox policies:
- pass-vpc-cidr: validates VPC uses proper private CIDR block
- pass-multi-az-subnets: validates subnets across multiple AZs

Component policies (ec2):
- pass-instance-tags: validates EC2 has required tags
- warn-public-security-group: warns on public access (0.0.0.0/0)
