### PR TITLE
feat: add 4 policies to ecs-simple

### DIFF
--- a/ecs-simple/policies.toml
+++ b/ecs-simple/policies.toml
@@ -15,3 +15,9 @@ type       = "terraform_module"
 engine     = "opa"
 components = ["alb"]
 contents   = "./policies/warn-alb-public-access.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["whoami"]
+contents   = "./policies/warn-minimal-task-resources.rego"

--- a/ecs-simple/policies.toml
+++ b/ecs-simple/policies.toml
@@ -4,3 +4,8 @@
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-vpc-cidr.rego"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-multi-az-subnets.rego"

--- a/ecs-simple/policies.toml
+++ b/ecs-simple/policies.toml
@@ -9,3 +9,9 @@ contents = "./policies/pass-vpc-cidr.rego"
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-multi-az-subnets.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["alb"]
+contents   = "./policies/warn-alb-public-access.rego"

--- a/ecs-simple/policies.toml
+++ b/ecs-simple/policies.toml
@@ -1,1 +1,6 @@
+# policies
 
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-vpc-cidr.rego"

--- a/ecs-simple/policies/pass-multi-az-subnets.rego
+++ b/ecs-simple/policies/pass-multi-az-subnets.rego
@@ -1,0 +1,24 @@
+package nuon
+
+# Pass when subnets are distributed across multiple availability zones
+pass contains msg if {
+    subnet_resources := [resource | 
+        resource := input.plan.resource_changes[_]
+        resource.type == "aws_subnet"
+        resource.change.actions[_] in ["create", "update"]
+    ]
+    
+    # Get unique availability zones
+    azs := {az | 
+        subnet := subnet_resources[_]
+        az := subnet.change.after.availability_zone
+    }
+    
+    # Check if we have multiple AZs
+    count(azs) > 1
+    
+    msg := sprintf(
+        "Subnets are distributed across %d availability zones for high availability",
+        [count(azs)],
+    )
+}

--- a/ecs-simple/policies/pass-vpc-cidr.rego
+++ b/ecs-simple/policies/pass-vpc-cidr.rego
@@ -1,0 +1,45 @@
+package nuon
+
+# Pass when VPC uses a proper private CIDR block (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    # Check if CIDR starts with valid private range
+    startswith(cidr, "10.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "172.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "192.168.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}

--- a/ecs-simple/policies/warn-alb-public-access.rego
+++ b/ecs-simple/policies/warn-alb-public-access.rego
@@ -1,0 +1,17 @@
+package nuon
+
+# Warn when ALB security group allows public access (0.0.0.0/0)
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_security_group"
+    resource.change.actions[_] in ["create", "update"]
+    
+    # Check for ingress rules with 0.0.0.0/0
+    some ingress in resource.change.after.ingress
+    "0.0.0.0/0" in ingress.cidr_blocks
+    
+    msg := sprintf(
+        "Security group '%s' allows public access (0.0.0.0/0) - ensure this is intentional for public-facing ALB",
+        [resource.address],
+    )
+}

--- a/ecs-simple/policies/warn-minimal-task-resources.rego
+++ b/ecs-simple/policies/warn-minimal-task-resources.rego
@@ -1,0 +1,35 @@
+package nuon
+
+# Warn when ECS task uses minimal CPU/memory (suitable for demos, not production)
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_ecs_task_definition"
+    resource.change.actions[_] in ["create", "update"]
+    
+    cpu := resource.change.after.cpu
+    memory := resource.change.after.memory
+    
+    # Check if CPU is minimal (256 = 0.25 vCPU)
+    cpu == "256"
+    
+    msg := sprintf(
+        "ECS task '%s' uses minimal CPU (%s) - suitable for demos but consider increasing for production workloads",
+        [resource.address, cpu],
+    )
+}
+
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_ecs_task_definition"
+    resource.change.actions[_] in ["create", "update"]
+    
+    memory := resource.change.after.memory
+    
+    # Check if memory is minimal (512 MB)
+    memory == "512"
+    
+    msg := sprintf(
+        "ECS task '%s' uses minimal memory (%s MB) - suitable for demos but consider increasing for production workloads",
+        [resource.address, memory],
+    )
+}


### PR DESCRIPTION
add 4 policies to ecs-simple

Sandbox policies:
- pass-vpc-cidr: validates VPC uses proper private CIDR block
- pass-multi-az-subnets: validates subnets across multiple AZs

Component policies:
- warn-alb-public-access: warns on ALB public access (alb component)
- warn-minimal-task-resources: warns on minimal task resources (whoami component)
