### PR TITLE
feat: add 4 policies to eks-simple

### DIFF
--- a/eks-simple/policies.toml
+++ b/eks-simple/policies.toml
@@ -11,3 +11,8 @@ contents = "./policies/pass-vpc-cidr.rego"
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-multi-az-subnets.rego"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/warn-public-eks-endpoint.rego"

--- a/eks-simple/policies.toml
+++ b/eks-simple/policies.toml
@@ -6,3 +6,8 @@ contents = "./policies/disallow-ingress-nginx-custom-snippets.yml"
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-vpc-cidr.rego"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-multi-az-subnets.rego"

--- a/eks-simple/policies.toml
+++ b/eks-simple/policies.toml
@@ -16,3 +16,9 @@ contents = "./policies/pass-multi-az-subnets.rego"
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/warn-public-eks-endpoint.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["certificate"]
+contents   = "./policies/warn-wildcard-certificate.rego"

--- a/eks-simple/policies.toml
+++ b/eks-simple/policies.toml
@@ -3,6 +3,10 @@ type = "kubernetes_cluster"
 contents = "./policies/disallow-ingress-nginx-custom-snippets.yml"
 
 [[policy]]
+type = "kubernetes_cluster"
+contents = "./policies/set-karpenter-non-cpu-limits.yaml"
+
+[[policy]]
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-vpc-cidr.rego"

--- a/eks-simple/policies.toml
+++ b/eks-simple/policies.toml
@@ -1,3 +1,8 @@
 [[policy]]
 type = "kubernetes_cluster"
 contents = "./policies/disallow-ingress-nginx-custom-snippets.yml"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-vpc-cidr.rego"

--- a/eks-simple/policies/pass-multi-az-subnets.rego
+++ b/eks-simple/policies/pass-multi-az-subnets.rego
@@ -1,0 +1,24 @@
+package nuon
+
+# Pass when subnets are distributed across multiple availability zones
+pass contains msg if {
+    subnet_resources := [resource | 
+        resource := input.plan.resource_changes[_]
+        resource.type == "aws_subnet"
+        resource.change.actions[_] in ["create", "update"]
+    ]
+    
+    # Get unique availability zones
+    azs := {az | 
+        subnet := subnet_resources[_]
+        az := subnet.change.after.availability_zone
+    }
+    
+    # Check if we have multiple AZs
+    count(azs) > 1
+    
+    msg := sprintf(
+        "Subnets are distributed across %d availability zones for high availability",
+        [count(azs)],
+    )
+}

--- a/eks-simple/policies/pass-vpc-cidr.rego
+++ b/eks-simple/policies/pass-vpc-cidr.rego
@@ -1,0 +1,45 @@
+package nuon
+
+# Pass when VPC uses a proper private CIDR block (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    # Check if CIDR starts with valid private range
+    startswith(cidr, "10.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "172.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "192.168.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}

--- a/eks-simple/policies/warn-public-eks-endpoint.rego
+++ b/eks-simple/policies/warn-public-eks-endpoint.rego
@@ -1,0 +1,13 @@
+package nuon
+
+# Warn when EKS cluster has public endpoint access enabled
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_eks_cluster"
+    resource.change.actions[_] in ["create", "update"]
+    resource.change.after.vpc_config[_].endpoint_public_access == true
+    msg := sprintf(
+        "EKS cluster '%s' has public endpoint access enabled - ensure this is intentional for demo/development environments",
+        [resource.address],
+    )
+}

--- a/eks-simple/policies/warn-wildcard-certificate.rego
+++ b/eks-simple/policies/warn-wildcard-certificate.rego
@@ -1,0 +1,14 @@
+package nuon
+
+# Warn when ACM certificate uses wildcard domain
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_acm_certificate"
+    resource.change.actions[_] in ["create", "update"]
+    domain := resource.change.after.domain_name
+    startswith(domain, "*.")
+    msg := sprintf(
+        "Certificate '%s' uses wildcard domain '%s' - consider using specific domain names for production",
+        [resource.address, domain],
+    )
+}


### PR DESCRIPTION
add 4 OPA policies and register orphaned Karpenter policy to eks-simple

Sandbox policies (OPA):
- pass-vpc-cidr: validates VPC uses proper private CIDR block
- pass-multi-az-subnets: validates subnets across multiple AZs
- warn-public-eks-endpoint: warns on public EKS endpoint access

Component policies (OPA):
- warn-wildcard-certificate: warns on wildcard domain (certificate component)

Kubernetes policy:
- Registered existing set-karpenter-non-cpu-limits.yaml
