### PR TITLE
feat: add 4 policies to aws-lambda

### DIFF
--- a/aws-lambda/policies.toml
+++ b/aws-lambda/policies.toml
@@ -1,3 +1,8 @@
 [[policy]]
 type     = "kubernetes_cluster"
 contents = "./policies/disallow-ingress-nginx-custom-snippets.yaml"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-vpc-cidr.rego"

--- a/aws-lambda/policies.toml
+++ b/aws-lambda/policies.toml
@@ -17,3 +17,9 @@ type       = "terraform_module"
 engine     = "opa"
 components = ["dynamodb_table"]
 contents   = "./policies/warn-dynamodb-on-demand.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["lambda_function"]
+contents   = "./policies/warn-lambda-minimal-memory.rego"

--- a/aws-lambda/policies.toml
+++ b/aws-lambda/policies.toml
@@ -11,3 +11,9 @@ contents = "./policies/pass-vpc-cidr.rego"
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-multi-az-subnets.rego"
+
+[[policy]]
+type       = "terraform_module"
+engine     = "opa"
+components = ["dynamodb_table"]
+contents   = "./policies/warn-dynamodb-on-demand.rego"

--- a/aws-lambda/policies.toml
+++ b/aws-lambda/policies.toml
@@ -6,3 +6,8 @@ contents = "./policies/disallow-ingress-nginx-custom-snippets.yaml"
 type     = "sandbox"
 engine   = "opa"
 contents = "./policies/pass-vpc-cidr.rego"
+
+[[policy]]
+type     = "sandbox"
+engine   = "opa"
+contents = "./policies/pass-multi-az-subnets.rego"

--- a/aws-lambda/policies/pass-multi-az-subnets.rego
+++ b/aws-lambda/policies/pass-multi-az-subnets.rego
@@ -1,0 +1,24 @@
+package nuon
+
+# Pass when subnets are distributed across multiple availability zones
+pass contains msg if {
+    subnet_resources := [resource | 
+        resource := input.plan.resource_changes[_]
+        resource.type == "aws_subnet"
+        resource.change.actions[_] in ["create", "update"]
+    ]
+    
+    # Get unique availability zones
+    azs := {az | 
+        subnet := subnet_resources[_]
+        az := subnet.change.after.availability_zone
+    }
+    
+    # Check if we have multiple AZs
+    count(azs) > 1
+    
+    msg := sprintf(
+        "Subnets are distributed across %d availability zones for high availability",
+        [count(azs)],
+    )
+}

--- a/aws-lambda/policies/pass-vpc-cidr.rego
+++ b/aws-lambda/policies/pass-vpc-cidr.rego
@@ -1,0 +1,45 @@
+package nuon
+
+# Pass when VPC uses a proper private CIDR block (10.0.0.0/8, 172.16.0.0/12, or 192.168.0.0/16)
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    # Check if CIDR starts with valid private range
+    startswith(cidr, "10.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "172.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}
+
+pass contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_vpc"
+    resource.change.actions[_] in ["create", "update"]
+    cidr := resource.change.after.cidr_block
+    
+    startswith(cidr, "192.168.")
+    
+    msg := sprintf(
+        "VPC '%s' uses proper private CIDR block: %s",
+        [resource.address, cidr],
+    )
+}

--- a/aws-lambda/policies/warn-dynamodb-on-demand.rego
+++ b/aws-lambda/policies/warn-dynamodb-on-demand.rego
@@ -1,0 +1,14 @@
+package nuon
+
+# Warn when DynamoDB table uses on-demand billing mode
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_dynamodb_table"
+    resource.change.actions[_] in ["create", "update"]
+    billing_mode := resource.change.after.billing_mode
+    billing_mode == "PAY_PER_REQUEST"
+    msg := sprintf(
+        "DynamoDB table '%s' uses on-demand billing (PAY_PER_REQUEST) - consider provisioned capacity for predictable workloads",
+        [resource.address],
+    )
+}

--- a/aws-lambda/policies/warn-lambda-minimal-memory.rego
+++ b/aws-lambda/policies/warn-lambda-minimal-memory.rego
@@ -1,0 +1,17 @@
+package nuon
+
+# Warn when Lambda function uses minimal memory allocation
+warn contains msg if {
+    some resource in input.plan.resource_changes
+    resource.type == "aws_lambda_function"
+    resource.change.actions[_] in ["create", "update"]
+    memory := resource.change.after.memory_size
+    
+    # Check if memory is minimal (128-512 MB)
+    memory <= 512
+    
+    msg := sprintf(
+        "Lambda function '%s' uses minimal memory (%d MB) - suitable for demos but consider increasing for production workloads",
+        [resource.address, memory],
+    )
+}


### PR DESCRIPTION
add 4 policies to aws-lambda

Sandbox policies:
- pass-vpc-cidr: validates VPC uses proper private CIDR block
- pass-multi-az-subnets: validates subnets across multiple AZs

Component policies:
- warn-dynamodb-on-demand: warns on DynamoDB on-demand billing (dynamodb_table component)
- warn-lambda-minimal-memory: warns on minimal Lambda memory allocation (lambda_function component)
