### PR TITLE
feat(coder): full-healthcheck + refresh_coder_data runbooks with live tiles

### DIFF
--- a/coder/README.md
+++ b/coder/README.md
@@ -1,28 +1,68 @@
-<center>
+{{ $k8s     := default dict (index (default dict .nuon.actions.workflows) "k8s_status") }}
+{{ $coder   := default dict (index (default dict .nuon.actions.workflows) "coder_health") }}
+{{ $db      := default dict (index (default dict .nuon.actions.workflows) "db_ping") }}
+{{ $alb     := default dict (index (default dict .nuon.actions.workflows) "alb_healthcheck") }}
+{{ $grafana := default dict (index (default dict .nuon.actions.workflows) "grafana_health") }}
+{{ $prom    := default dict (index (default dict .nuon.actions.workflows) "prom_targets") }}
 
-  <video autoplay loop muted playsinline width="640" height="360">
+{{ $k8sInd   := dig "outputs" "indicator" "" $k8s }}
+{{ $coderInd := dig "outputs" "indicator" "" $coder }}
+{{ $dbInd    := dig "outputs" "indicator" "" $db }}
+{{ $grafInd  := dig "outputs" "indicator" "" $grafana }}
+{{ $promInd  := dig "outputs" "indicator" "" $prom }}
+{{ $albCoder := dig "outputs" "coder" "indicator" "" $alb }}
+{{ $albGraf  := dig "outputs" "grafana" "indicator" "" $alb }}
+
+{{ $hcAllGreen := and (eq $k8sInd "🟢") (eq $coderInd "🟢") (eq $dbInd "🟢") (eq $albCoder "🟢") (eq $albGraf "🟢") (eq $grafInd "🟢") (eq $promInd "🟢") }}
+{{ $hcAnyRed   := or  (eq $k8sInd "🔴") (eq $coderInd "🔴") (eq $dbInd "🔴") (eq $albCoder "🔴") (eq $albGraf "🔴") (eq $grafInd "🔴") (eq $promInd "🔴") }}
+
+{{ $prov   := default dict (index (default dict .nuon.actions.workflows) "coder_provisioners") }}
+{{ $provOut    := dig "outputs" dict $prov }}
+{{ $provReady  := and (dig "populated" false $prov) (eq (dig "status" "" $prov) "finished") }}
+
+{{ $ws     := default dict (index (default dict .nuon.actions.workflows) "coder_workspaces") }}
+{{ $wsOut      := dig "outputs" dict $ws }}
+{{ $wsReady    := and (dig "populated" false $ws) (eq (dig "status" "" $ws) "finished") }}
+
+{{ $ut     := default dict (index (default dict .nuon.actions.workflows) "coder_users_templates") }}
+{{ $utOut      := dig "outputs" dict $ut }}
+{{ $utReady    := and (dig "populated" false $ut) (eq (dig "status" "" $ut) "finished") }}
+
+{{ $bj     := default dict (index (default dict .nuon.actions.workflows) "coder_builds_jobs") }}
+{{ $bjOut      := dig "outputs" dict $bj }}
+{{ $bjReady    := and (dig "populated" false $bj) (eq (dig "status" "" $bj) "finished") }}
+
+{{ $dh    := default dict (index (default dict .nuon.actions.workflows) "coder_deployment_health") }}
+{{ $dhOut    := dig "outputs" dict $dh }}
+{{ $dhSub    := dig "subsystems" dict $dhOut }}
+{{ $dhReady  := and (dig "populated" false $dh) (eq (dig "status" "" $dh) "finished") }}
+
+{{ $ag    := default dict (index (default dict .nuon.actions.workflows) "coder_agents_health") }}
+{{ $agOut    := dig "outputs" dict $ag }}
+{{ $agReady  := and (dig "populated" false $ag) (eq (dig "status" "" $ag) "finished") }}
+{{ $agCount  := dig "count" 0 $agOut }}
+
+{{ $tf    := default dict (index (default dict .nuon.actions.workflows) "coder_template_freshness") }}
+{{ $tfOut    := dig "outputs" dict $tf }}
+{{ $tfReady  := and (dig "populated" false $tf) (eq (dig "status" "" $tf) "finished") }}
+{{ $tfCount  := dig "count" 0 $tfOut }}
+
+<div style="display:flex; width:100%; align-items:center; justify-content:space-between; padding-bottom:1rem;">
+  <video autoplay loop muted playsinline width="480" height="270">
     <source src="https://coder.together.agency/videos/logo/sections/0/content/9/value/video.mp4" type="video/mp4">
     Your browser does not support the video tag.
   </video>
-</center>
+  <div style="display:flex; flex-direction:column; gap:10px; align-items:flex-end;">
+    <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:#8b5cf6; color:white; border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Coder →</a>
+    <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/grafana" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:transparent; color:#c4b5fd; border:1px solid rgba(139,92,246,0.6); border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Grafana →</a>
+    <nuon-run-runbook name="full-healthcheck"></nuon-run-runbook>
+    <nuon-run-runbook name="refresh_coder_data"></nuon-run-runbook>
+  </div>
+</div>
 
 <nuon-banner theme="success">
-Coder's Cloud Development Environment platform running in the customer's AWS account. The URLs and component statuses below are bound to this install.
+Coder's cloud development environment platform — for developers and agents. The links and status below are live for this install.
 </nuon-banner>
-
-<br/>
-
-<nuon-group gap="8" align="center">
-  <nuon-badge theme="info">Coder</nuon-badge>
-  <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}">Open Coder</a>
-</nuon-group>
-
-<br/>
-
-<nuon-group gap="8" align="center">
-  <nuon-badge theme="info">Grafana</nuon-badge>
-  <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/grafana">Open Grafana</a>
-</nuon-group>
 
 <br/>
 
@@ -37,6 +77,205 @@ Coder's Cloud Development Environment platform running in the customer's AWS acc
 <nuon-tab name="overview">
 
 <br/>
+
+<div style="display:flex; flex-direction:column;">
+
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Install healthcheck</p>
+
+<nuon-group gap="8" align="center">
+  {{ if $hcAllGreen }}<nuon-status status="active" variant="badge"></nuon-status>
+  {{ else if $hcAnyRed }}<nuon-status status="error" variant="badge"></nuon-status>
+  {{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}
+  <span>Rolled-up status from the six <strong>full-healthcheck</strong> steps.</span>
+</nuon-group>
+
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Deployment health</p>
+
+{{ if $dhReady }}
+<table>
+  <thead><tr><th>Subsystem</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td>Access URL</td><td>{{ $s := dig "access_url" "" $dhSub }}{{ if eq $s "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $s "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Database</td><td>{{ $s := dig "database" "" $dhSub }}{{ if eq $s "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $s "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Provisioner daemons</td><td>{{ $s := dig "provisioner_daemons" "" $dhSub }}{{ if eq $s "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $s "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>DERP</td><td>{{ $s := dig "derp" "" $dhSub }}{{ if eq $s "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $s "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Websocket</td><td>{{ $s := dig "websocket" "" $dhSub }}{{ if eq $s "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $s "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Workspace proxy</td><td>{{ $s := dig "workspace_proxy" "" $dhSub }}{{ if eq $s "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $s "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+  </tbody>
+</table>
+{{ else }}
+<nuon-banner theme="warn">Waiting on <code>coder_deployment_health</code> action. Run it from the Operations tab to populate.</nuon-banner>
+{{ end }}
+
+{{ if and $agReady (gt $agCount 0.0) }}
+<nuon-banner theme="warn">{{ $agCount }} workspace(s) marked running but the agent is disconnected.</nuon-banner>
+<table>
+  <thead><tr><th>Workspace</th><th>Agent</th><th>Disconnected</th></tr></thead>
+  <tbody>
+{{ range $d := dig "disconnected" (list) $agOut }}
+    <tr>
+      <td><code>{{ dig "workspace" "—" $d }}</code></td>
+      <td><code>{{ dig "agent" "—" $d }}</code></td>
+      <td>{{ dig "disconnected_sec" "—" $d }}s</td>
+    </tr>
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
+
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Workspaces</p>
+
+{{ if $wsReady }}
+{{ $counts := dig "counts" (dict) $wsOut }}
+{{ if eq (len $counts) 0 }}
+<nuon-banner theme="info">No workspaces yet.</nuon-banner>
+{{ else }}
+<table>
+  <thead><tr><th>Status</th><th>Count</th></tr></thead>
+  <tbody>
+{{ range $status, $count := $counts }}
+    <tr><td><code>{{ $status }}</code></td><td>{{ $count }}</td></tr>
+{{ end }}
+  </tbody>
+</table>
+
+{{ $recent := dig "recent" (list) $wsOut }}
+{{ if gt (len $recent) 0 }}
+
+<p style="font-weight:600; margin-top:0.75rem; margin-bottom:0.5rem;">Recently active</p>
+
+<table>
+  <thead><tr><th>Workspace</th><th>Status</th><th>Last used</th></tr></thead>
+  <tbody>
+{{ range $w := $recent }}
+    <tr>
+      <td><code>{{ dig "name" "—" $w }}</code></td>
+      <td><code>{{ dig "status" "—" $w }}</code></td>
+      <td>{{ with dig "last_used_at" "" $w }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="relative"></nuon-time>{{ else }}—{{ end }}</td>
+    </tr>
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
+{{ end }}
+{{ else }}
+<nuon-banner theme="warn">Waiting on <code>coder_workspaces</code> action. Run it from the Operations tab to populate.</nuon-banner>
+{{ end }}
+
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Users & templates</p>
+
+{{ if $utReady }}
+{{ $u := dig "users" (dict) $utOut }}
+
+<table>
+  <thead><tr><th>Total users</th><th>Active</th><th>Active 24h</th><th>Dormant</th><th>Suspended</th></tr></thead>
+  <tbody>
+    <tr>
+      <td>{{ dig "total" 0 $u }}</td>
+      <td>{{ dig "active" 0 $u }}</td>
+      <td>{{ dig "active_24h" 0 $u }}</td>
+      <td>{{ dig "dormant" 0 $u }}</td>
+      <td>{{ dig "suspended" 0 $u }}</td>
+    </tr>
+  </tbody>
+</table>
+
+{{ $templates := dig "templates" (list) $utOut }}
+{{ if eq (len $templates) 0 }}
+<nuon-banner theme="info">No templates configured yet.</nuon-banner>
+{{ else }}
+
+<p style="font-weight:600; margin-top:0.75rem; margin-bottom:0.5rem;">Templates</p>
+
+<table>
+  <thead><tr><th>Template</th><th>Display name</th><th>Workspaces</th></tr></thead>
+  <tbody>
+{{ range $t := $templates }}
+    <tr>
+      <td><code>{{ dig "name" "—" $t }}</code></td>
+      <td>{{ dig "display_name" "—" $t }}</td>
+      <td>{{ dig "workspace_count" 0 $t }}</td>
+    </tr>
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
+{{ else }}
+<nuon-banner theme="warn">Waiting on <code>coder_users_templates</code> action. Run it from the Operations tab to populate.</nuon-banner>
+{{ end }}
+
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Recent builds & job queue</p>
+
+{{ if $bjReady }}
+{{ $queue := dig "queue" (dict) $bjOut }}
+{{ if gt (len $queue) 0 }}
+
+<p style="font-weight:600; margin-top:0.75rem; margin-bottom:0.5rem;">Job queue (last hour)</p>
+
+<table>
+  <thead><tr><th>Status</th><th>Count</th></tr></thead>
+  <tbody>
+{{ range $status, $count := $queue }}
+    <tr><td><code>{{ $status }}</code></td><td>{{ $count }}</td></tr>
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
+
+{{ $builds := dig "recent_builds" (list) $bjOut }}
+{{ if gt (len $builds) 0 }}
+
+<p style="font-weight:600; margin-top:0.75rem; margin-bottom:0.5rem;">Last 10 builds</p>
+
+<table>
+  <thead><tr><th>Workspace</th><th>Transition</th><th>Job status</th><th>Started</th></tr></thead>
+  <tbody>
+{{ range $b := $builds }}
+    <tr>
+      <td><code>{{ dig "workspace_name" "—" $b }}</code></td>
+      <td><code>{{ dig "transition" "—" $b }}</code></td>
+      <td><code>{{ dig "job_status" "—" $b }}</code></td>
+      <td>{{ with dig "created_at" "" $b }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="relative"></nuon-time>{{ else }}—{{ end }}</td>
+    </tr>
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
+{{ else }}
+<nuon-banner theme="warn">Waiting on <code>coder_builds_jobs</code> action. Run it from the Operations tab to populate.</nuon-banner>
+{{ end }}
+
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Provisioners</p>
+
+{{ if $provReady }}
+{{ $daemons := dig "daemons" (list) $provOut }}
+{{ if eq (len $daemons) 0 }}
+<nuon-banner theme="info">No provisioner daemons registered yet.</nuon-banner>
+{{ else }}
+<table>
+  <thead><tr><th>Name</th><th>Status</th><th>Last seen</th><th>Version</th></tr></thead>
+  <tbody>
+{{ range $d := $daemons }}
+{{ $age := dig "age_sec" 9999 $d }}
+{{ if lt $age 300.0 }}
+    <tr>
+      <td><code>{{ dig "name" "—" $d }}</code></td>
+      <td>{{ if lt $age 60.0 }}<nuon-status status="active" variant="badge"></nuon-status>{{ else }}<nuon-status status="error" variant="badge"></nuon-status>{{ end }}</td>
+      <td>{{ $age }}s ago</td>
+      <td><code>{{ dig "version" "—" $d }}</code></td>
+    </tr>
+{{ end }}
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
+{{ else }}
+<nuon-banner theme="warn">Waiting on <code>coder_provisioners</code> action. Run it from the Operations tab to populate.</nuon-banner>
+{{ end }}
+
+</div>
+
+### About this install
 
 Coder is a Cloud Development Environment (CDE) platform that lets your team create and manage cloud-hosted development environments from a central dashboard.
 
@@ -54,43 +293,7 @@ This install is fully provisioned in your AWS account — EKS, RDS Postgres, ALB
   <nuon-component-card name="observability"></nuon-component-card>
 </nuon-group>
 
-> [!TIP]
-> Component cards reflect live state for this install. Green = healthy. Click any card to drill into its workflow history and logs.
-
-### First steps
-
-1. Open the Coder URL above and sign in
-2. Create a workspace template — start from the [example templates](https://github.com/coder/coder/tree/main/examples/templates)
-3. Invite your developers from the Coder admin UI
-4. (Optional) Wire up the AI gateway — see the **AI Agents** tab
-
 [Coder documentation](https://coder.com/docs) · [Workspace templates](https://coder.com/docs/templates) · [User management](https://coder.com/docs/admin/users)
-
-</nuon-tab>
-
-<nuon-tab name="quick start">
-
-<br/>
-
-### Prerequisites
-
-- AWS account where you've applied Nuon's CloudFormation stack — the stack provisions a Nuon Runner inside your VPC that phones home to the Nuon control plane to pull deploy steps and day-2 actions
-- Sufficient AWS service quota in your target region for EKS, RDS, and ALBs
-- Optional — the [Coder CLI](https://coder.com/docs/install) for terminal/SSH workspace access
-
-### Day 1 — get to a working environment
-
-1. Sign in at the Coder URL above with the admin credentials from setup
-2. Import a workspace template (use [the examples](https://github.com/coder/coder/tree/main/examples/templates) or write your own)
-3. Create your first workspace from that template
-4. Invite the rest of the team
-
-### Day 2 — operate it
-
-Switch to the **Operations** tab for common day-2 actions (retrieve Grafana password, run troubleshoot, health-check the ALB) and the **Observability** tab for dashboards.
-
-> [!NOTE]
-> All actions run against this install with the credentials Nuon already has — you don't need AWS CLI access or `kubectl` to operate Coder day-to-day.
 
 </nuon-tab>
 
@@ -284,14 +487,35 @@ Day-2 actions you can run from here. Each one executes inside your install with 
   <nuon-action-card name="alb_healthcheck"></nuon-action-card>
   <nuon-action-card name="grafana_setup"></nuon-action-card>
   <nuon-action-card name="coder_rds_creds"></nuon-action-card>
+  <nuon-action-card name="coder_deployment_health"></nuon-action-card>
+  <nuon-action-card name="coder_agents_health"></nuon-action-card>
+  <nuon-action-card name="coder_template_freshness"></nuon-action-card>
 </nuon-group>
+
+{{ if and $tfReady (gt $tfCount 0.0) }}
+<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Stale templates (90+ days)</p>
+
+<table>
+  <thead><tr><th>Template</th><th>Display name</th><th>Stale</th><th>Workspaces</th></tr></thead>
+  <tbody>
+{{ range $t := dig "stale" (list) $tfOut }}
+    <tr>
+      <td><code>{{ dig "name" "—" $t }}</code></td>
+      <td>{{ dig "display_name" "—" $t }}</td>
+      <td>{{ dig "stale_days" 0 $t }}d</td>
+      <td>{{ dig "workspace_count" 0 $t }}</td>
+    </tr>
+{{ end }}
+  </tbody>
+</table>
+{{ end }}
 
 ### Upgrading Coder
 
 Coder release version is vendor-managed (see the **Configuration** tab). The vendor publishes a new `release` value through an app config update; your install picks up the change on its next sync. You'll see a pending deploy in **Workflows** with a Helm diff — review and approve to apply.
 
 > [!WARNING]
-> Major Coder upgrades may include database migrations. Review the Coder release notes before approving the workflow — migrations run as part of the helm upgrade and are not separately reversible.
+> Major Coder upgrades may include database migrations. Review the [Coder release notes](https://github.com/coder/coder/releases) before approving the workflow — migrations run as part of the helm upgrade and are not separately reversible.
 
 </nuon-tab>
 

--- a/coder/actions/coder-agents-health.toml
+++ b/coder/actions/coder-agents-health.toml
@@ -1,0 +1,92 @@
+# action
+
+name    = "coder_agents_health"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-agents-health"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-agents-health: running workspaces with disconnected agents"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+read -r -d '' SQL <<'EOF' || true
+WITH latest AS (
+  SELECT DISTINCT ON (workspace_id)
+    workspace_id, job_id, transition
+  FROM workspace_builds
+  ORDER BY workspace_id, build_number DESC
+),
+running AS (
+  SELECT w.id, w.name, l.job_id
+  FROM workspaces w
+  JOIN latest l           ON l.workspace_id = w.id
+  JOIN provisioner_jobs pj ON pj.id = l.job_id
+  WHERE w.deleted = false
+    AND l.transition = 'start'
+    AND pj.completed_at IS NOT NULL
+    AND pj.error IS NULL
+),
+agents AS (
+  SELECT r.name AS workspace,
+         wa.name AS agent,
+         wa.last_connected_at,
+         EXTRACT(EPOCH FROM (NOW() - wa.last_connected_at))::int AS disconnected_sec
+  FROM running r
+  JOIN workspace_resources wr ON wr.job_id = r.job_id
+  JOIN workspace_agents    wa ON wa.resource_id = wr.id
+  WHERE wa.last_connected_at IS NULL
+     OR wa.last_connected_at < NOW() - INTERVAL '5 minutes'
+)
+SELECT json_build_object(
+  'count', (SELECT COUNT(*) FROM agents),
+  'disconnected', COALESCE((SELECT json_agg(row_to_json(a)) FROM (
+    SELECT workspace, agent,
+           COALESCE(last_connected_at::text, '') AS last_connected_at,
+           disconnected_sec
+    FROM agents
+    ORDER BY disconnected_sec DESC NULLS FIRST
+    LIMIT 20
+  ) a), '[]'::json)
+);
+EOF
+
+pod="psql-ag-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tAc "$SQL" 2>&1 || true)
+
+data=$(printf '%s\n' "$raw" | grep -E '^\{' | head -1 || true)
+[ -z "$data" ] && data='{"count":0,"disconnected":[]}'
+
+count=$(echo "$data" | jq '.count // 0')
+
+if [ "$count" = "0" ]; then ind="🟢"; else ind="🔴"; fi
+
+output=$(jq --null-input -c \
+  --arg ind "$ind" \
+  --argjson count "$count" \
+  --argjson data "$data" \
+  '{indicator: $ind, count: $count, disconnected: $data.disconnected}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/coder-builds-jobs.toml
+++ b/coder/actions/coder-builds-jobs.toml
@@ -1,0 +1,87 @@
+# action
+
+name    = "coder_builds_jobs"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-builds-jobs"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-builds-jobs: last 10 builds + provisioner_jobs queue (last hour)"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+read -r -d '' SQL <<'EOF' || true
+SELECT json_build_object(
+  'recent_builds', COALESCE((SELECT json_agg(row_to_json(b)) FROM (
+    SELECT
+      w.name AS workspace_name,
+      wb.transition,
+      wb.created_at::text AS created_at,
+      pj.job_status,
+      COALESCE(pj.completed_at::text, '') AS completed_at,
+      COALESCE(pj.error, '')             AS error
+    FROM workspace_builds wb
+    JOIN workspaces w        ON w.id = wb.workspace_id
+    JOIN provisioner_jobs pj ON pj.id = wb.job_id
+    ORDER BY wb.created_at DESC
+    LIMIT 10
+  ) b), '[]'::json),
+  'queue', COALESCE((SELECT json_object_agg(status, c) FROM (
+    SELECT
+      CASE
+        WHEN started_at IS NULL                                THEN 'pending'
+        WHEN completed_at IS NULL                              THEN 'running'
+        WHEN canceled_at IS NOT NULL OR error IS NOT NULL      THEN 'failed'
+        ELSE 'completed'
+      END AS status,
+      COUNT(*) AS c
+    FROM provisioner_jobs
+    WHERE created_at > NOW() - INTERVAL '1 hour'
+    GROUP BY status
+  ) q), '{}'::json)
+);
+EOF
+
+pod="psql-bj-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tAc "$SQL" 2>&1 || true)
+
+data=$(printf '%s\n' "$raw" | grep -E '^\{' | head -1 || true)
+[ -z "$data" ] && data='{"recent_builds":[],"queue":{}}'
+
+failed=$(echo "$data" | jq '.queue.failed // 0')
+pending=$(echo "$data" | jq '.queue.pending // 0')
+
+# Indicator: red if any failed jobs in last hour; yellow if >5 pending; else green.
+if [ "$failed" != "0" ]; then ind="🔴"
+elif [ "$pending" -gt 5 ] 2>/dev/null; then ind="🟡"
+else ind="🟢"
+fi
+
+output=$(jq --null-input -c \
+  --arg ind "$ind" \
+  --argjson data "$data" \
+  '{indicator: $ind, recent_builds: $data.recent_builds, queue: $data.queue}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/coder-deployment-health.toml
+++ b/coder/actions/coder-deployment-health.toml
@@ -1,0 +1,101 @@
+# action
+
+name    = "coder_deployment_health"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-deployment-health"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-deployment-health: 6-subsystem health matrix"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+access_http=$(curl --silent --max-time 15 -o /dev/null -w '%{http_code}' "$CODER_URL/api/v2/buildinfo" || echo 000)
+if [ "$access_http" = "200" ]; then access="🟢"; else access="🔴"; fi
+
+derp_http=$(curl --silent --max-time 10 -o /dev/null -w '%{http_code}' "$CODER_URL/derp/latency-check" || echo 000)
+case "$derp_http" in
+  200)    derp="🟢" ;;
+  000|5*) derp="🔴" ;;
+  *)      [ "$access" = "🟢" ] && derp="🟢" || derp="🔴" ;;
+esac
+
+ws_http=$(curl --silent --max-time 10 -o /dev/null -w '%{http_code}' \
+  -H "Connection: Upgrade" \
+  -H "Upgrade: websocket" \
+  -H "Sec-WebSocket-Version: 13" \
+  -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+  "$CODER_URL/api/v2/workspaceagents/me/coordinate" || echo 000)
+case "$ws_http" in
+  101|401|426) websocket="🟢" ;;
+  000|5*)      websocket="🔴" ;;
+  *)           [ "$access" = "🟢" ] && websocket="🟢" || websocket="🔴" ;;
+esac
+
+if [ "$access" = "🟢" ]; then proxy="🟢"; else proxy="🔴"; fi
+
+pod="psql-dh-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tA --set=ON_ERROR_STOP=off \
+    -c "SELECT 'db_ok:1';" \
+    -c "SELECT 'prov_count:' || COUNT(*) FROM provisioner_daemons WHERE last_seen_at > NOW() - INTERVAL '60 seconds';" \
+  2>&1 || true)
+
+echo "--- psql raw output ---"
+echo "$raw"
+echo "--- end psql output ---"
+
+db_ok=$(echo "$raw"      | grep -E '^db_ok:'      | head -1 | cut -d: -f2)
+prov_count=$(echo "$raw" | grep -E '^prov_count:' | head -1 | cut -d: -f2)
+
+[ -z "$db_ok" ]      && db_ok=0
+[ -z "$prov_count" ] && prov_count=0
+
+if [ "$db_ok" = "1" ]; then database="🟢"; else database="🔴"; fi
+if [ "$prov_count" -gt 0 ] 2>/dev/null; then provisioner="🟢"; else provisioner="🔴"; fi
+
+reds=0
+for s in "$access" "$database" "$provisioner" "$derp" "$websocket" "$proxy"; do
+  [ "$s" = "🔴" ] && reds=$((reds+1))
+done
+if [ "$reds" -gt 0 ]; then overall="🔴"; else overall="🟢"; fi
+
+output=$(jq --null-input -c \
+  --arg ind "$overall" \
+  --arg access "$access" --arg database "$database" --arg provisioner "$provisioner" \
+  --arg derp "$derp" --arg websocket "$websocket" --arg proxy "$proxy" \
+  --arg access_http "$access_http" --arg derp_http "$derp_http" --arg ws_http "$ws_http" \
+  '{indicator: $ind,
+    subsystems: {
+      access_url: $access,
+      database: $database,
+      provisioner_daemons: $provisioner,
+      derp: $derp,
+      websocket: $websocket,
+      workspace_proxy: $proxy
+    },
+    probes: {access_http: $access_http, derp_http: $derp_http, ws_http: $ws_http}}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"
+CODER_URL       = "https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}"

--- a/coder/actions/coder-health.toml
+++ b/coder/actions/coder-health.toml
@@ -1,0 +1,59 @@
+# action
+
+name    = "coder_health"
+timeout = "1m"
+enable_kube_config = false
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-health"
+inline_contents = '''
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+url="$CODER_URL/api/v2/buildinfo"
+echo "==> coder-health: $url"
+
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+http=$(curl --silent --show-error --max-time 30 --retry 3 --retry-delay 5 \
+  -o "$tmp" -w '%{http_code}' "$url")
+body=$(cat "$tmp")
+
+if [ "$http" != "200" ]; then
+  indicator="🔴"
+  rc=1
+  output=$(jq --null-input -c \
+    --arg indicator "$indicator" --arg url "$url" \
+    --arg http "$http" --arg body "$body" \
+    '{indicator: $indicator, url: $url, http_code: $http, body: $body}')
+else
+  version=$(echo    "$body" | jq -r '.version       // "unknown"')
+  deployment=$(echo "$body" | jq -r '.deployment_id // null')
+  dashboard=$(echo  "$body" | jq -r '.dashboard_url // null')
+  if [ "$version" = "unknown" ] || [ "$version" = "null" ]; then
+    indicator="🔴"; rc=1
+  else
+    indicator="🟢"; rc=0
+  fi
+  output=$(jq --null-input -c \
+    --arg indicator "$indicator" --arg url "$url" \
+    --arg version "$version" --arg deployment "$deployment" --arg dashboard "$dashboard" \
+    '{indicator: $indicator, url: $url,
+      version: $version, deployment_id: $deployment, dashboard_url: $dashboard}')
+fi
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+exit $rc
+'''
+
+[steps.env_vars]
+CODER_URL = "https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}"

--- a/coder/actions/coder-provisioners.toml
+++ b/coder/actions/coder-provisioners.toml
@@ -1,0 +1,72 @@
+# action
+
+name    = "coder_provisioners"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-provisioners"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-provisioners: SELECT from provisioner_daemons via $DB_SECRET_NAME"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+read -r -d '' SQL <<'EOF' || true
+-- Filter out terminated/stale provisioners. Coder's heartbeat is ~60s; any
+-- daemon not seen in the last 5 minutes is from a previous pod replica that
+-- was rolled. Keeps the table to currently-active replicas only.
+SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json) FROM (
+  SELECT
+    name,
+    last_seen_at::text AS last_seen_at,
+    EXTRACT(EPOCH FROM (NOW() - last_seen_at))::int AS age_sec,
+    version
+  FROM provisioner_daemons
+  WHERE last_seen_at > NOW() - INTERVAL '5 minutes'
+  ORDER BY last_seen_at DESC NULLS LAST
+) t;
+EOF
+
+pod="psql-prov-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tAc "$SQL" 2>&1 || true)
+
+data=$(printf '%s\n' "$raw" | grep -E '^\[' | head -1 || true)
+[ -z "$data" ] && data="[]"
+
+total=$(echo "$data" | jq 'length' 2>/dev/null || echo 0)
+healthy=$(echo "$data" | jq '[.[] | select(.age_sec != null and .age_sec < 60)] | length' 2>/dev/null || echo 0)
+
+if [ "$total" = "0" ]; then ind="🔴"
+elif [ "$healthy" = "0" ]; then ind="🔴"
+else ind="🟢"
+fi
+
+output=$(jq --null-input -c \
+  --arg ind "$ind" \
+  --argjson data "$data" \
+  --argjson total "$total" \
+  --argjson healthy "$healthy" \
+  '{indicator: $ind, total: $total, healthy: $healthy, daemons: $data}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/coder-template-freshness.toml
+++ b/coder/actions/coder-template-freshness.toml
@@ -1,0 +1,67 @@
+# action
+
+name    = "coder_template_freshness"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-template-freshness"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-template-freshness: templates not updated in 90+ days"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+read -r -d '' SQL <<'EOF' || true
+SELECT COALESCE(json_agg(row_to_json(t)), '[]'::json) FROM (
+  SELECT
+    t.name,
+    t.display_name,
+    t.updated_at::text                                                  AS updated_at,
+    (EXTRACT(EPOCH FROM (NOW() - t.updated_at)) / 86400)::int           AS stale_days,
+    (SELECT COUNT(*) FROM workspaces w
+      WHERE w.template_id = t.id AND w.deleted = false)                  AS workspace_count
+  FROM templates t
+  WHERE t.deleted = false
+    AND t.updated_at < NOW() - INTERVAL '90 days'
+  ORDER BY t.updated_at ASC
+) t;
+EOF
+
+pod="psql-tf-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tAc "$SQL" 2>&1 || true)
+
+data=$(printf '%s\n' "$raw" | grep -E '^\[' | head -1 || true)
+[ -z "$data" ] && data="[]"
+
+count=$(echo "$data" | jq 'length')
+
+if [ "$count" = "0" ]; then ind="🟢"; else ind="🟡"; fi
+
+output=$(jq --null-input -c \
+  --arg ind "$ind" \
+  --argjson count "$count" \
+  --argjson stale "$data" \
+  '{indicator: $ind, count: $count, stale: $stale}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/coder-users-templates.toml
+++ b/coder/actions/coder-users-templates.toml
@@ -1,0 +1,74 @@
+# action
+
+name    = "coder_users_templates"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-users-templates"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-users-templates: user counts + template list with workspace counts"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+read -r -d '' SQL <<'EOF' || true
+SELECT json_build_object(
+  'users', (SELECT json_build_object(
+    'total',      COUNT(*),
+    'active',     COUNT(*) FILTER (WHERE status = 'active'),
+    'dormant',    COUNT(*) FILTER (WHERE status = 'dormant'),
+    'suspended',  COUNT(*) FILTER (WHERE status = 'suspended'),
+    'active_24h', COUNT(*) FILTER (WHERE last_seen_at > NOW() - INTERVAL '24 hours')
+  ) FROM users WHERE deleted = false),
+  'templates', COALESCE((SELECT json_agg(row_to_json(t)) FROM (
+    SELECT
+      t.name,
+      t.display_name,
+      COALESCE(t.deprecated, '') AS deprecated,
+      (SELECT COUNT(*) FROM workspaces w WHERE w.template_id = t.id AND w.deleted = false) AS workspace_count
+    FROM templates t
+    WHERE t.deleted = false
+    ORDER BY workspace_count DESC, t.name
+  ) t), '[]'::json)
+);
+EOF
+
+pod="psql-ut-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tAc "$SQL" 2>&1 || true)
+
+data=$(printf '%s\n' "$raw" | grep -E '^\{' | head -1 || true)
+[ -z "$data" ] && data='{"users":{},"templates":[]}'
+
+user_total=$(echo "$data" | jq '.users.total // 0')
+tpl_count=$(echo "$data" | jq '.templates | length')
+
+# Indicator: green if at least one user and at least one template exist.
+if [ "$user_total" != "0" ] && [ "$tpl_count" != "0" ]; then ind="🟢"; else ind="🟡"; fi
+
+output=$(jq --null-input -c \
+  --arg ind "$ind" \
+  --argjson data "$data" \
+  '{indicator: $ind, users: $data.users, templates: $data.templates}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/coder-workspaces.toml
+++ b/coder/actions/coder-workspaces.toml
@@ -1,0 +1,102 @@
+# action
+
+name    = "coder_workspaces"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "coder-workspaces"
+inline_contents = '''
+#!/usr/bin/env bash
+set -o pipefail
+set -u
+
+echo "==> coder-workspaces: workspaces grouped by latest-build status"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
+if [ -z "$url" ]; then
+  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  exit 1
+fi
+
+read -r -d '' SQL <<'EOF' || true
+WITH latest AS (
+  SELECT DISTINCT ON (workspace_id)
+    workspace_id,
+    transition,
+    job_id,
+    created_at
+  FROM workspace_builds
+  ORDER BY workspace_id, build_number DESC
+),
+joined AS (
+  SELECT
+    w.id,
+    w.name,
+    w.deleted,
+    w.last_used_at,
+    l.transition,
+    pj.job_status,
+    pj.completed_at,
+    pj.canceled_at,
+    pj.error,
+    CASE
+      WHEN w.deleted THEN 'deleted'
+      WHEN l.transition = 'delete' THEN 'deleted'
+      WHEN pj.error IS NOT NULL OR pj.canceled_at IS NOT NULL THEN 'failed'
+      WHEN l.transition = 'stop'  AND pj.completed_at IS NOT NULL THEN 'stopped'
+      WHEN l.transition = 'start' AND pj.completed_at IS NOT NULL THEN 'running'
+      WHEN pj.completed_at IS NULL THEN 'pending'
+      ELSE 'unknown'
+    END AS status
+  FROM workspaces w
+  LEFT JOIN latest l         ON l.workspace_id = w.id
+  LEFT JOIN provisioner_jobs pj ON pj.id = l.job_id
+)
+SELECT json_build_object(
+  'counts',  COALESCE((SELECT json_object_agg(status, c) FROM (SELECT status, COUNT(*) AS c FROM joined GROUP BY status) s), '{}'::json),
+  'recent', COALESCE((SELECT json_agg(row_to_json(r)) FROM (
+              SELECT name, status, last_used_at::text AS last_used_at
+              FROM joined
+              WHERE status != 'deleted'
+              ORDER BY last_used_at DESC NULLS LAST
+              LIMIT 10
+            ) r), '[]'::json)
+);
+EOF
+
+pod="psql-ws-$(date +%s)-$$"
+raw=$(kubectl run "$pod" -n "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine --command -- \
+  psql "$url" -tAc "$SQL" 2>&1 || true)
+
+data=$(printf '%s\n' "$raw" | grep -E '^\{' | head -1 || true)
+[ -z "$data" ] && data='{"counts":{},"recent":[]}'
+
+failed=$(echo "$data" | jq '.counts.failed // 0')
+total=$(echo "$data" | jq '[.counts | to_entries[] | select(.key != "deleted") | .value] | add // 0')
+
+if [ "$failed" != "0" ]; then ind="🔴"
+elif [ "$total" = "0" ]; then ind="🟢"
+else ind="🟢"
+fi
+
+output=$(jq --null-input -c \
+  --arg ind "$ind" \
+  --argjson data "$data" \
+  --argjson total "$total" \
+  --argjson failed "$failed" \
+  '{indicator: $ind, total_active: $total, failed: $failed, counts: $data.counts, recent: $data.recent}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/db-ping.toml
+++ b/coder/actions/db-ping.toml
@@ -1,0 +1,65 @@
+# action
+
+name    = "db_ping"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "db-ping"
+inline_contents = '''
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+echo "==> db-ping: SELECT 1 via $DB_SECRET_NAME in $CODER_NAMESPACE"
+
+url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
+  -o jsonpath='{.data.url}' | base64 -d)
+if [ -z "$url" ]; then
+  echo "secret $CODER_NAMESPACE/$DB_SECRET_NAME has empty .data.url" >&2
+  exit 1
+fi
+
+pod="db-ping-$(date +%s)-$$"
+
+start=$(date +%s)
+result=$(kubectl run "$pod" \
+  --namespace "$CODER_NAMESPACE" \
+  --rm -i --restart=Never --quiet \
+  --image=postgres:16-alpine \
+  --command -- psql "$url" -tAc 'SELECT 1;' 2>&1 || true)
+end=$(date +%s)
+
+got=$(printf '%s\n' "$result" | grep -E '^1$' | head -1 || true)
+elapsed_s=$(( end - start ))
+
+if [ "$got" = "1" ]; then
+  indicator="🟢"
+  rc=0
+else
+  indicator="🔴"
+  rc=1
+fi
+
+output=$(jq --null-input -c \
+  --arg indicator "$indicator" \
+  --arg secret    "$DB_SECRET_NAME" \
+  --arg namespace "$CODER_NAMESPACE" \
+  --argjson elapsed_s "$elapsed_s" \
+  --arg raw "$result" \
+  '{indicator: $indicator, namespace: $namespace, secret: $secret, elapsed_s: $elapsed_s, raw: $raw}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+exit $rc
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+DB_SECRET_NAME  = "coder-db-url"

--- a/coder/actions/grafana-health.toml
+++ b/coder/actions/grafana-health.toml
@@ -1,0 +1,49 @@
+# action
+
+name    = "grafana_health"
+timeout = "1m"
+enable_kube_config = false
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "grafana-health"
+inline_contents = '''
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+url="$GRAFANA_URL/api/health"
+echo "==> grafana-health: $url"
+
+body=$(curl --silent --show-error --max-time 30 --retry 3 --retry-delay 5 "$url")
+
+database=$(echo "$body" | jq -r '.database // "unknown"')
+version=$(echo  "$body" | jq -r '.version  // "unknown"')
+
+if [ "$database" = "ok" ]; then
+  indicator="🟢"
+  rc=0
+else
+  indicator="🔴"
+  rc=1
+fi
+
+output=$(jq --null-input -c \
+  --arg indicator "$indicator" \
+  --arg url       "$url" \
+  --arg database  "$database" \
+  --arg version   "$version" \
+  '{indicator: $indicator, url: $url, database: $database, version: $version}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+exit $rc
+'''
+
+[steps.env_vars]
+GRAFANA_URL = "https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/grafana"

--- a/coder/actions/k8s-status.toml
+++ b/coder/actions/k8s-status.toml
@@ -1,0 +1,105 @@
+# action
+
+name    = "k8s_status"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "k8s-status"
+inline_contents = '''
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+echo "==> k8s-status: $CODER_NAMESPACE, $OBS_NAMESPACE"
+
+nodes_json=$(kubectl get nodes -o json)
+nodes_total=$(echo "$nodes_json" | jq '.items | length')
+nodes_ready=$(echo "$nodes_json" | jq '[.items[] | select(.status.conditions[]? | select(.type=="Ready" and .status=="True"))] | length')
+
+pod_stats() {
+  ns=$1
+  kubectl get pods -n "$ns" -o json | jq -c --arg ns "$ns" '{
+    namespace: $ns,
+    total: (.items | length),
+    ready: ([.items[]
+      | select(((.status.containerStatuses // []) | length) > 0
+              and ((.status.containerStatuses // []) | all(.ready)))] | length),
+    not_ready: [.items[]
+      | select(((.status.containerStatuses // []) | any(.ready | not))
+              or (.status.phase != "Running" and .status.phase != "Succeeded"))
+      | {name: .metadata.name, phase: .status.phase,
+         reason: (.status.containerStatuses // [] | map(.state | keys[0]?) | join(","))}]
+  }'
+}
+
+deploy_stats() {
+  ns=$1
+  kubectl get deployments -n "$ns" -o json | jq -c --arg ns "$ns" '{
+    namespace: $ns,
+    total: (.items | length),
+    available: ([.items[]
+      | select((.status.availableReplicas // 0) == (.spec.replicas // 0))] | length),
+    under_replicated: [.items[]
+      | select((.status.availableReplicas // 0) != (.spec.replicas // 0))
+      | {name: .metadata.name,
+         want: (.spec.replicas // 0),
+         have: (.status.availableReplicas // 0)}]
+  }'
+}
+
+coder_pods=$(pod_stats "$CODER_NAMESPACE")
+obs_pods=$(pod_stats "$OBS_NAMESPACE")
+coder_deploys=$(deploy_stats "$CODER_NAMESPACE")
+obs_deploys=$(deploy_stats "$OBS_NAMESPACE")
+
+fail=0
+for stats in "$coder_pods" "$obs_pods"; do
+  if [ "$(echo "$stats" | jq '.not_ready | length')" != "0" ]; then
+    fail=1
+  fi
+done
+for stats in "$coder_deploys" "$obs_deploys"; do
+  if [ "$(echo "$stats" | jq '.under_replicated | length')" != "0" ]; then
+    fail=1
+  fi
+done
+if [ "$nodes_ready" -lt "$nodes_total" ]; then
+  fail=1
+fi
+
+if [ "$fail" = "0" ]; then
+  indicator="🟢"
+else
+  indicator="🔴"
+fi
+
+output=$(jq --null-input -c \
+  --arg indicator "$indicator" \
+  --argjson nodes_total "$nodes_total" \
+  --argjson nodes_ready "$nodes_ready" \
+  --argjson coder_pods "$coder_pods" \
+  --argjson obs_pods "$obs_pods" \
+  --argjson coder_deploys "$coder_deploys" \
+  --argjson obs_deploys "$obs_deploys" \
+  '{
+    indicator: $indicator,
+    nodes: {total: $nodes_total, ready: $nodes_ready},
+    pods: [$coder_pods, $obs_pods],
+    deployments: [$coder_deploys, $obs_deploys]
+  }')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+[ "$fail" = "0" ] || exit 1
+'''
+
+[steps.env_vars]
+CODER_NAMESPACE = "coder"
+OBS_NAMESPACE   = "coder-observability"

--- a/coder/actions/prom-targets.toml
+++ b/coder/actions/prom-targets.toml
@@ -1,0 +1,66 @@
+# action
+
+name    = "prom_targets"
+timeout = "2m"
+enable_kube_config = true
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "prom-targets"
+inline_contents = '''
+#!/usr/bin/env sh
+
+set -e
+set -o pipefail
+set -u
+
+echo "==> prom-targets: querying Prometheus /api/v1/targets in $OBS_NAMESPACE"
+
+pod=$(kubectl get pods -n "$OBS_NAMESPACE" \
+  -l app.kubernetes.io/name=prometheus,app.kubernetes.io/component=server \
+  -o jsonpath='{.items[0].metadata.name}')
+
+if [ -z "$pod" ]; then
+  echo "no Prometheus server pod found in $OBS_NAMESPACE" >&2
+  exit 1
+fi
+
+# The prometheus-server image is distroless busybox; wget is available.
+body=$(kubectl exec -n "$OBS_NAMESPACE" "$pod" -c prometheus-server -- \
+  wget -qO- 'http://localhost:9090/api/v1/targets?state=active')
+
+down=$(echo "$body" | jq -c '
+  [.data.activeTargets[]
+   | select(.health != "up")
+   | {job: .labels.job, instance: .labels.instance, health: .health, lastError: .lastError}]
+')
+down_count=$(echo "$down" | jq 'length')
+total=$(echo "$body" | jq '.data.activeTargets | length')
+up=$(( total - down_count ))
+
+if [ "$down_count" = "0" ]; then
+  indicator="🟢"
+  rc=0
+else
+  indicator="🔴"
+  rc=1
+fi
+
+output=$(jq --null-input -c \
+  --arg indicator "$indicator" \
+  --arg pod "$pod" \
+  --argjson total "$total" \
+  --argjson up "$up" \
+  --argjson down "$down" \
+  '{indicator: $indicator, pod: $pod, total: $total, up: $up, down: $down}')
+
+echo "$output" | jq .
+echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+
+exit $rc
+'''
+
+[steps.env_vars]
+OBS_NAMESPACE = "coder-observability"

--- a/coder/runbooks/full-healthcheck.md
+++ b/coder/runbooks/full-healthcheck.md
@@ -1,0 +1,98 @@
+{{ $k8s     := default dict (index (default dict .nuon.actions.workflows) "k8s_status") }}
+{{ $coder   := default dict (index (default dict .nuon.actions.workflows) "coder_health") }}
+{{ $db      := default dict (index (default dict .nuon.actions.workflows) "db_ping") }}
+{{ $alb     := default dict (index (default dict .nuon.actions.workflows) "alb_healthcheck") }}
+{{ $grafana := default dict (index (default dict .nuon.actions.workflows) "grafana_health") }}
+{{ $prom    := default dict (index (default dict .nuon.actions.workflows) "prom_targets") }}
+
+{{ $k8sInd   := dig "outputs" "indicator" "" $k8s }}
+{{ $coderInd := dig "outputs" "indicator" "" $coder }}
+{{ $dbInd    := dig "outputs" "indicator" "" $db }}
+{{ $grafInd  := dig "outputs" "indicator" "" $grafana }}
+{{ $promInd  := dig "outputs" "indicator" "" $prom }}
+
+{{ $albCoder := dig "outputs" "coder" "indicator" "" $alb }}
+{{ $albGraf  := dig "outputs" "grafana" "indicator" "" $alb }}
+{{ $albInd   := "" }}
+{{ if and (eq $albCoder "🟢") (eq $albGraf "🟢") }}{{ $albInd = "🟢" }}{{ else if or (eq $albCoder "🔴") (eq $albGraf "🔴") }}{{ $albInd = "🔴" }}{{ end }}
+
+{{ $anyMissing := or (eq $k8sInd "") (eq $coderInd "") (eq $dbInd "") (eq $albInd "") (eq $grafInd "") (eq $promInd "") }}
+
+<div style="padding-top:1rem;"></div>
+
+End-to-end healthcheck across Kubernetes, Coder, RDS, ALB, Grafana, and Prometheus. A green run means: the cluster is healthy, Coder's `/api/v2/buildinfo` responds with a version, RDS accepts a `SELECT 1`, both ALB ingresses have a load balancer hostname, Grafana reports `database: ok`, and every Prometheus scrape target is up.
+
+{{ if $anyMissing }}
+<nuon-banner theme="warn">One or more sub-checks haven't run yet. Click <strong>Run runbook</strong> at the top right to populate every status.</nuon-banner>
+<br/>
+{{ end }}
+
+<table>
+  <thead>
+    <tr><th>#</th><th>Step</th><th>Status</th><th>Action</th><th>What it checks</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>1</td>
+      <td>k8s-status</td>
+      <td>{{ if eq $k8sInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $k8sInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><code>k8s_status</code></td>
+      <td>Pods, deployments, and nodes in <code>coder</code> and <code>coder-observability</code> namespaces</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>coder-health</td>
+      <td>{{ if eq $coderInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $coderInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><code>coder_health</code></td>
+      <td><code>/api/v2/buildinfo</code> returns 200 with a <code>version</code></td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>db-ping</td>
+      <td>{{ if eq $dbInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $dbInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><code>db_ping</code></td>
+      <td><code>SELECT 1;</code> against RDS via a throwaway <code>postgres:16-alpine</code> pod</td>
+    </tr>
+    <tr>
+      <td>4</td>
+      <td>alb-status</td>
+      <td>{{ if eq $albInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $albInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><code>alb_healthcheck</code></td>
+      <td>Both Coder and Grafana ingresses have a load balancer hostname</td>
+    </tr>
+    <tr>
+      <td>5</td>
+      <td>grafana-health</td>
+      <td>{{ if eq $grafInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $grafInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><code>grafana_health</code></td>
+      <td><code>/grafana/api/health</code> reports <code>database: ok</code></td>
+    </tr>
+    <tr>
+      <td>6</td>
+      <td>prom-targets</td>
+      <td>{{ if eq $promInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $promInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td>
+      <td><code>prom_targets</code></td>
+      <td>Every Prometheus active target reports <code>health: up</code></td>
+    </tr>
+  </tbody>
+</table>
+
+Each step is also runnable on its own from the **Operations** tab. Steps run cheapest-first so a failure in a foundational step short-circuits the rest in a useful way.
+
+### Triage
+
+If a step is red, expand the latest run under the **Run history** tab and look at the action's JSON output:
+
+- **k8s-status** — `pods[*].not_ready` and `deployments[*].under_replicated` name the broken pod or deployment. Hit it with `kubectl describe` from the `troubleshoot` action.
+- **coder-health** — non-200 from `/api/v2/buildinfo`. Almost always the ALB or a crashed coder pod.
+- **db-ping** — the `raw` field has psql's stderr. Common: the `coder-db-url` secret is missing (re-run `coder_rds_creds` from Operations), RDS is down, or the security group is blocking the throwaway pod.
+- **alb-status** — `loadBalancer.ingress[]` is empty. Check the ALB controller deployment in `kube-system`; the ingress's events usually point at a cert or subnet issue.
+- **grafana-health** — `database != ok` means the Grafana → RDS path is broken. Usually the `coder-db-password` secret in `coder-observability`.
+- **prom-targets** — the `down[]` array lists each target with `job`, `instance`, and `lastError`. Usually a NetworkPolicy, a crashed scrape target, or a wrong port.
+
+For per-subsystem Coder detail (`database`, `derp`, `websocket`, `workspace_proxy`, `provisioner_daemons`), the Coder owner can open <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/health">the Coder health page</a> in a browser — gated by their own session login, no API token to mint.
+
+### Notes
+
+- Run after install completes, after upgrades, or whenever you want a single green/red signal before opening dashboards.
+- Out of scope: log bundling (use the `troubleshoot` action), ALB external reachability from the public internet (the `coder-health` and `grafana-health` curls cover that path implicitly), workspace-level health.

--- a/coder/runbooks/full-healthcheck.toml
+++ b/coder/runbooks/full-healthcheck.toml
@@ -1,0 +1,37 @@
+name        = "full-healthcheck"
+description = "End-to-end healthcheck across Kubernetes, Coder, RDS, ALB, Grafana, and Prometheus."
+readme      = "./runbooks/full-healthcheck.md"
+
+[labels]
+team = "platform"
+kind = "healthcheck"
+
+[[steps]]
+name        = "k8s-status"
+type        = "action"
+action_name = "k8s_status"
+
+[[steps]]
+name        = "coder-health"
+type        = "action"
+action_name = "coder_health"
+
+[[steps]]
+name        = "db-ping"
+type        = "action"
+action_name = "db_ping"
+
+[[steps]]
+name        = "alb-status"
+type        = "action"
+action_name = "alb_healthcheck"
+
+[[steps]]
+name        = "grafana-health"
+type        = "action"
+action_name = "grafana_health"
+
+[[steps]]
+name        = "prom-targets"
+type        = "action"
+action_name = "prom_targets"

--- a/coder/runbooks/refresh_coder_data.md
+++ b/coder/runbooks/refresh_coder_data.md
@@ -1,0 +1,15 @@
+Refreshes every Coder data table on the install README in one shot — deployment health matrix, agent connectivity, template freshness, provisioner status, workspaces, users, templates, builds, and the job queue. Mix of `psql` queries against the Coder Postgres database via the `coder-db-url` secret and unauthenticated calls to public Coder endpoints (`/api/v2/buildinfo`, `/derp/latency-check`). No Coder API token required.
+
+Use this after creating new workspaces, deploying templates, registering provisioner daemons, or whenever the install dashboard tables look stale.
+
+**Actions**
+
+| Action | Populates |
+|---|---|
+| `coder_deployment_health`  | 6-subsystem health matrix (access url, database, provisioner daemons, derp, websocket, workspace proxy) |
+| `coder_agents_health`      | Running workspaces with disconnected agents (warn banner only if count > 0) |
+| `coder_template_freshness` | Templates not updated in 90+ days |
+| `coder_provisioners`       | Provisioners table — name, last-seen status (green if <60s), version |
+| `coder_workspaces`         | Workspace counts by status + recently active workspaces |
+| `coder_users_templates`    | User counts (total, active, dormant, suspended) + templates with workspace counts |
+| `coder_builds_jobs`        | Last 10 workspace builds + provisioner job queue (last hour) |

--- a/coder/runbooks/refresh_coder_data.toml
+++ b/coder/runbooks/refresh_coder_data.toml
@@ -1,0 +1,42 @@
+name        = "refresh_coder_data"
+description = "Refreshes the Coder data tables on the install README — deployment health, agents, template freshness, provisioners, workspaces, users, templates, builds, job queue — by querying the Coder database and public API directly."
+readme      = "./runbooks/refresh_coder_data.md"
+
+[labels]
+team = "platform"
+kind = "refresh"
+
+[[steps]]
+name        = "coder-deployment-health"
+type        = "action"
+action_name = "coder_deployment_health"
+
+[[steps]]
+name        = "coder-agents-health"
+type        = "action"
+action_name = "coder_agents_health"
+
+[[steps]]
+name        = "coder-template-freshness"
+type        = "action"
+action_name = "coder_template_freshness"
+
+[[steps]]
+name        = "coder-provisioners"
+type        = "action"
+action_name = "coder_provisioners"
+
+[[steps]]
+name        = "coder-workspaces"
+type        = "action"
+action_name = "coder_workspaces"
+
+[[steps]]
+name        = "coder-users-templates"
+type        = "action"
+action_name = "coder_users_templates"
+
+[[steps]]
+name        = "coder-builds-jobs"
+type        = "action"
+action_name = "coder_builds_jobs"


### PR DESCRIPTION
Adds two runbooks and the supporting actions so the Coder install README doubles as a status console.

- full-healthcheck runbook — k8s status, coder API, db ping, ALB, grafana, prometheus targets; rolled-up indicator
- refresh_coder_data runbook — deployment health matrix, disconnected agents, stale templates, provisioners, workspaces, users+templates, builds+jobs
- README now renders live tables under Overview driven by action outputs; warn banners when an action hasn't run yet
- deployment_health probes derp/websocket via direct HTTP probes (/derp/latency-check, WS upgrade); workspace_proxy mirrors access_url since the primary proxy is Coder itself
- removed quick start tab (redundant with Coder docs) and the auth-posture and engagement tiles (low-signal for this install)