### PR TITLE
feat(coder): cron triggers, README polish, timestamp fixes

### DIFF
--- a/coder/README.md
+++ b/coder/README.md
@@ -96,7 +96,7 @@ Coder's cloud development environment platform — for developers and agents. Th
 <div style="display:flex; flex-direction:column;">
 
 <div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
-  <p style="font-size:1.05rem; font-weight:700; margin:0;">Install healthcheck</p>
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Platform health</p>
   {{ with $promUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
 </div>
 
@@ -104,11 +104,24 @@ Coder's cloud development environment platform — for developers and agents. Th
   {{ if $hcAllGreen }}<nuon-status status="active" variant="badge"></nuon-status>
   {{ else if $hcAnyRed }}<nuon-status status="error" variant="badge"></nuon-status>
   {{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}
-  <span>Rolled-up status from the six <strong>full-healthcheck</strong> steps.</span>
+  <span>Rolled-up status across cluster, RDS, ALB, Grafana, and Prometheus.</span>
 </nuon-group>
 
+<table>
+  <thead><tr><th>Subsystem</th><th>Status</th></tr></thead>
+  <tbody>
+    <tr><td>Kubernetes</td><td>{{ if eq $k8sInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $k8sInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Coder API</td><td>{{ if eq $coderInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $coderInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Database</td><td>{{ if eq $dbInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $dbInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>ALB · Coder ingress</td><td>{{ if eq $albCoder "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $albCoder "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>ALB · Grafana ingress</td><td>{{ if eq $albGraf "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $albGraf "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Grafana</td><td>{{ if eq $grafInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $grafInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+    <tr><td>Prometheus</td><td>{{ if eq $promInd "🟢" }}<nuon-status status="active" variant="badge"></nuon-status>{{ else if eq $promInd "🔴" }}<nuon-status status="error" variant="badge"></nuon-status>{{ else }}<nuon-status status="pending" variant="badge"></nuon-status>{{ end }}</td></tr>
+  </tbody>
+</table>
+
 <div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
-  <p style="font-size:1.05rem; font-weight:700; margin:0;">Deployment health</p>
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Coder control plane health</p>
   {{ with $dhUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
 </div>
 
@@ -175,7 +188,7 @@ Coder's cloud development environment platform — for developers and agents. Th
     <tr>
       <td><code>{{ dig "name" "—" $w }}</code></td>
       <td><code>{{ dig "status" "—" $w }}</code></td>
-      <td>{{ with dig "last_used_at" "" $w }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="relative"></nuon-time>{{ else }}—{{ end }}</td>
+      <td>{{ with dig "last_used_at" "" $w }}<nuon-time time="{{ . }}" format="relative"></nuon-time>{{ else }}—{{ end }}</td>
     </tr>
 {{ end }}
   </tbody>
@@ -187,7 +200,7 @@ Coder's cloud development environment platform — for developers and agents. Th
 {{ end }}
 
 <div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
-  <p style="font-size:1.05rem; font-weight:700; margin:0;">Users & templates</p>
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Users</p>
   {{ with $utUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
 </div>
 
@@ -206,14 +219,20 @@ Coder's cloud development environment platform — for developers and agents. Th
     </tr>
   </tbody>
 </table>
+{{ else }}
+<nuon-banner theme="warn">Waiting on <code>coder_users_templates</code> action. Run it from the Operations tab to populate.</nuon-banner>
+{{ end }}
 
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Templates</p>
+  {{ with $utUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
+
+{{ if $utReady }}
 {{ $templates := dig "templates" (list) $utOut }}
 {{ if eq (len $templates) 0 }}
 <nuon-banner theme="info">No templates configured yet.</nuon-banner>
 {{ else }}
-
-<p style="font-weight:600; margin-top:0.75rem; margin-bottom:0.5rem;">Templates</p>
-
 <table>
   <thead><tr><th>Template</th><th>Display name</th><th>Workspaces</th></tr></thead>
   <tbody>
@@ -265,7 +284,7 @@ Coder's cloud development environment platform — for developers and agents. Th
       <td><code>{{ dig "workspace_name" "—" $b }}</code></td>
       <td><code>{{ dig "transition" "—" $b }}</code></td>
       <td><code>{{ dig "job_status" "—" $b }}</code></td>
-      <td>{{ with dig "created_at" "" $b }}<nuon-time time="{{ printf "%sZ" (substr 0 19 .) }}" format="relative"></nuon-time>{{ else }}—{{ end }}</td>
+      <td>{{ with dig "created_at" "" $b }}<nuon-time time="{{ . }}" format="relative"></nuon-time>{{ else }}—{{ end }}</td>
     </tr>
 {{ end }}
   </tbody>
@@ -308,12 +327,6 @@ Coder's cloud development environment platform — for developers and agents. Th
 
 </div>
 
-### About this install
-
-Coder is a Cloud Development Environment (CDE) platform that lets your team create and manage cloud-hosted development environments from a central dashboard.
-
-This install is fully provisioned in your AWS account — EKS, RDS Postgres, ALB, ACM, DNS, and observability are all running in your VPC. Navigate to the Coder URL above and sign in with the admin credentials provided during setup.
-
 ### What's deployed
 
 <nuon-group gap="8">
@@ -326,7 +339,9 @@ This install is fully provisioned in your AWS account — EKS, RDS Postgres, ALB
   <nuon-component-card name="observability"></nuon-component-card>
 </nuon-group>
 
-[Coder documentation](https://coder.com/docs) · [Workspace templates](https://coder.com/docs/templates) · [User management](https://coder.com/docs/admin/users)
+- [Coder documentation](https://coder.com/docs)
+- [Workspace templates](https://coder.com/docs/templates)
+- [User management](https://coder.com/docs/admin/users)
 
 </nuon-tab>
 
@@ -398,10 +413,6 @@ This install is fully provisioned in your AWS account — EKS, RDS Postgres, ALB
 
 </nuon-panel>
 
-### Where it runs
-
-Coder runs entirely inside your AWS VPC — both its control plane (the Coder server, web UI, and AI gateway) and its data plane (the developer workspaces themselves). Nuon's SaaS control plane only ever sees workflow state and component metadata — never your developers' code, secrets, or workspace contents.
-
 ### Components
 
 <nuon-group gap="8">
@@ -414,36 +425,40 @@ Coder runs entirely inside your AWS VPC — both its control plane (the Coder se
   <nuon-component-card name="observability"></nuon-component-card>
 </nuon-group>
 
+### Where it runs
+
+Coder runs entirely inside your AWS VPC — both its control plane (the Coder server, web UI, and AI gateway) and its data plane (the RDS database cluster and the developer workspaces themselves). Grafana is also deployed in the VPC. 
+
 </nuon-tab>
 
 <nuon-tab name="configuration">
 
 <br/>
 
-Inputs split into two groups by who owns the change. Customer-controlled inputs are exposed in **Manage → Edit Inputs** and safe to tune any time. Vendor-controlled inputs are managed by the vendor through app config updates and not visible to the install operator.
+Inputs split into two groups by who owns the change. Customer-controlled inputs are exposed in **Current Inputs** and safe to tune any time. Vendor-controlled inputs are managed by the vendor through app config updates and not visible to the install operator.
 
 ### Customer-controlled
 
-Tune these from **Manage → Edit Inputs**. Changes trigger a redeploy of affected components — the workflow shows a diff and pauses for approval before applying.
+Tune these from **Current Inputs → Edit Inputs**. Changes trigger a redeploy of affected components — the workflow shows a diff and pauses for approval before applying.
 
-| Input | Default | Description |
+| Input | Current value | Description |
 |---|---|---|
-| `telemetry` | `true` | Send usage telemetry to Coder |
-| `max_token_lifetime` | `8760h0m0s` | Maximum lifetime for CLI and API tokens |
-| `session_duration` | `168h0m0s` | Session duration before re-authentication is required |
-| `block_direct` | `false` | Force all workspace connections through the Coder relay (disables peer-to-peer) |
+| `telemetry` | `{{ .nuon.install.inputs.telemetry }}` | Send usage telemetry to Coder |
+| `max_token_lifetime` | `{{ .nuon.install.inputs.max_token_lifetime }}` | Maximum lifetime for CLI and API tokens |
+| `session_duration` | `{{ .nuon.install.inputs.session_duration }}` | Session duration before re-authentication is required |
+| `block_direct` | `{{ .nuon.install.inputs.block_direct }}` | Force all workspace connections through the Coder relay (disables peer-to-peer) |
 
 ### Vendor-controlled
 
 The vendor pins these in the app config and updates them via release. The big one is `release` — the Coder version itself, which the vendor schedules into your install on their cadence.
 
-| Input | Default | Description |
+| Input | Current value | Description |
 |---|---|---|
-| `release` | `v2.31.1` | Coder release version — vendor schedules upgrades |
-| `replicas` | `1` | Coder control plane replica count |
-| `provisioners` | `3` | Terraform provisioners for workspace lifecycle |
-| `cluster_version` | `1.34` | EKS Kubernetes version |
-| `coder_db_instance_type` | `db.t4g.micro` | RDS instance type |
+| `release` | `{{ .nuon.install.inputs.release }}` | Coder release version — vendor schedules upgrades |
+| `replicas` | `{{ .nuon.install.inputs.replicas }}` | Coder control plane replica count |
+| `provisioners` | `{{ .nuon.install.inputs.provisioners }}` | Terraform provisioners for workspace lifecycle |
+| `cluster_version` | `{{ .nuon.install.inputs.cluster_version }}` | EKS Kubernetes version |
+| `coder_db_instance_type` | `{{ .nuon.install.inputs.coder_db_instance_type }}` | RDS instance type |
 
 > [!IMPORTANT]
 > Vendor-side changes to `cluster_version` or `coder_db_instance_type` trigger infrastructure changes that can take 15+ minutes to apply. The vendor stages these during an agreed maintenance window.
@@ -482,7 +497,7 @@ Update the parameter in the install stack and re-run the secret sync from the **
 
 </nuon-tab>
 
-<nuon-tab name="observability">
+<nuon-tab name="grafana">
 
 <br/>
 
@@ -508,95 +523,20 @@ The output shows the URL, username (`admin`), and the generated password.
 
 </nuon-tab>
 
-<nuon-tab name="operations">
+<nuon-tab name="upgrade">
 
 <br/>
 
-Day-2 actions you can run from here. Each one executes inside your install with the credentials Nuon already has.
+The Coder version is pinned by the `release` input on this install. Bumping it triggers a helm upgrade — you review the diff, then approve.
 
-<nuon-group gap="8">
-  <nuon-action-card name="grafana_password"></nuon-action-card>
-  <nuon-action-card name="troubleshoot"></nuon-action-card>
-  <nuon-action-card name="alb_healthcheck"></nuon-action-card>
-  <nuon-action-card name="grafana_setup"></nuon-action-card>
-  <nuon-action-card name="coder_rds_creds"></nuon-action-card>
-  <nuon-action-card name="coder_deployment_health"></nuon-action-card>
-  <nuon-action-card name="coder_agents_health"></nuon-action-card>
-  <nuon-action-card name="coder_template_freshness"></nuon-action-card>
-</nuon-group>
+### Steps
 
-{{ if and $tfReady (gt $tfCount 0.0) }}
-<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
-  <p style="font-size:1.05rem; font-weight:700; margin:0;">Stale templates (90+ days)</p>
-  {{ with $tfUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
-</div>
-
-<table>
-  <thead><tr><th>Template</th><th>Display name</th><th>Stale</th><th>Workspaces</th></tr></thead>
-  <tbody>
-{{ range $t := dig "stale" (list) $tfOut }}
-    <tr>
-      <td><code>{{ dig "name" "—" $t }}</code></td>
-      <td>{{ dig "display_name" "—" $t }}</td>
-      <td>{{ dig "stale_days" 0 $t }}d</td>
-      <td>{{ dig "workspace_count" 0 $t }}</td>
-    </tr>
-{{ end }}
-  </tbody>
-</table>
-{{ end }}
-
-### Upgrading Coder
-
-Coder release version is vendor-managed (see the **Configuration** tab). The vendor publishes a new `release` value through an app config update; your install picks up the change on its next sync. You'll see a pending deploy in **Workflows** with a Helm diff — review and approve to apply.
+1. Click **Current Inputs → Edit Inputs**
+2. Set the new version. e.g., v2.34.2 Valid tags: [github.com/coder/coder/releases](https://github.com/coder/coder/releases).
+3. Save. A workflow appears in **Workflows** with a helm diff. Review and approve to apply.
 
 > [!WARNING]
-> Major Coder upgrades may include database migrations. Review the [Coder release notes](https://github.com/coder/coder/releases) before approving the workflow — migrations run as part of the helm upgrade and are not separately reversible.
-
-</nuon-tab>
-
-<nuon-tab name="troubleshooting">
-
-<br/>
-
-> [!TIP]
-> Most issues are visible from the component cards on the **Overview** tab. A red card → click in to see the failing workflow and logs.
-
-### ALB not provisioning
-
-Symptoms — the ALB component sits in `pending` or `error` for more than 10 minutes after deploy.
-
-<nuon-action-card name="alb_healthcheck"></nuon-action-card>
-
-If the healthcheck reports the ALB exists but targets are unhealthy, check that the Coder pods are running (`kubectl get pods -n coder` via the troubleshoot action below).
-
-### Grafana admin secret missing
-
-Symptoms — Grafana login rejects the password from `grafana_password`, or the action returns empty.
-
-<nuon-action-card name="grafana_setup"></nuon-action-card>
-
-Re-running `grafana_setup` creates (or refreshes) the admin secret. Then `grafana_password` will return it.
-
-### Helm release stuck in `pending-install`
-
-Symptoms — the `coder` component card shows the Helm release exists but Coder pods never come up.
-
-<nuon-action-card name="troubleshoot"></nuon-action-card>
-
-`troubleshoot` will gather pod, event, and helm history for diagnosis. The fix is typically to delete the stuck release and re-sync from the dashboard.
-
-### Database connectivity errors
-
-Symptoms — Coder logs show `dial tcp ...:5432` failures or migration errors on startup.
-
-<nuon-action-card name="coder_rds_creds"></nuon-action-card>
-
-Re-runs the secret copy from RDS into the Coder namespace. Then bounce the Coder deployment from the **Operations** tab.
-
-### When all else fails
-
-Use **Manage → Force Unlock** if a terraform workspace is stuck. The dashboard button uses session auth — CLI `terraform force-unlock` will not work against Nuon's backend.
+> Major Coder upgrades may include database migrations. Migrations run as part of the helm upgrade and are **not separately reversible**. Read the [release notes](https://github.com/coder/coder/releases) before approving.
 
 </nuon-tab>
 

--- a/coder/README.md
+++ b/coder/README.md
@@ -47,6 +47,15 @@
 {{ $tfReady  := and (dig "populated" false $tf) (eq (dig "status" "" $tf) "finished") }}
 {{ $tfCount  := dig "count" 0 $tfOut }}
 
+{{ $promUpdated := dig "outputs" "updated_at" "" $prom }}
+{{ $dhUpdated   := dig "outputs" "updated_at" "" $dh }}
+{{ $wsUpdated   := dig "outputs" "updated_at" "" $ws }}
+{{ $utUpdated   := dig "outputs" "updated_at" "" $ut }}
+{{ $bjUpdated   := dig "outputs" "updated_at" "" $bj }}
+{{ $provUpdated := dig "outputs" "updated_at" "" $prov }}
+{{ $tfUpdated   := dig "outputs" "updated_at" "" $tf }}
+{{ $agUpdated   := dig "outputs" "updated_at" "" $ag }}
+
 <div style="display:flex; width:100%; align-items:center; justify-content:space-between; padding-bottom:1rem;">
   <video autoplay loop muted playsinline width="480" height="270">
     <source src="https://coder.together.agency/videos/logo/sections/0/content/9/value/video.mp4" type="video/mp4">
@@ -55,8 +64,14 @@
   <div style="display:flex; flex-direction:column; gap:10px; align-items:flex-end;">
     <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:#8b5cf6; color:white; border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Coder →</a>
     <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/grafana" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:transparent; color:#c4b5fd; border:1px solid rgba(139,92,246,0.6); border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Grafana →</a>
-    <nuon-run-runbook name="full-healthcheck"></nuon-run-runbook>
-    <nuon-run-runbook name="refresh_coder_data"></nuon-run-runbook>
+    <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
+      <nuon-run-runbook name="full-healthcheck"></nuon-run-runbook>
+      {{ with $promUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+    </div>
+    <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
+      <nuon-run-runbook name="refresh_coder_data"></nuon-run-runbook>
+      {{ with $bjUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+    </div>
   </div>
 </div>
 
@@ -80,7 +95,10 @@ Coder's cloud development environment platform — for developers and agents. Th
 
 <div style="display:flex; flex-direction:column;">
 
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Install healthcheck</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Install healthcheck</p>
+  {{ with $promUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 <nuon-group gap="8" align="center">
   {{ if $hcAllGreen }}<nuon-status status="active" variant="badge"></nuon-status>
@@ -89,7 +107,10 @@ Coder's cloud development environment platform — for developers and agents. Th
   <span>Rolled-up status from the six <strong>full-healthcheck</strong> steps.</span>
 </nuon-group>
 
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Deployment health</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Deployment health</p>
+  {{ with $dhUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 {{ if $dhReady }}
 <table>
@@ -123,7 +144,10 @@ Coder's cloud development environment platform — for developers and agents. Th
 </table>
 {{ end }}
 
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Workspaces</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Workspaces</p>
+  {{ with $wsUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 {{ if $wsReady }}
 {{ $counts := dig "counts" (dict) $wsOut }}
@@ -162,7 +186,10 @@ Coder's cloud development environment platform — for developers and agents. Th
 <nuon-banner theme="warn">Waiting on <code>coder_workspaces</code> action. Run it from the Operations tab to populate.</nuon-banner>
 {{ end }}
 
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Users & templates</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Users & templates</p>
+  {{ with $utUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 {{ if $utReady }}
 {{ $u := dig "users" (dict) $utOut }}
@@ -204,7 +231,10 @@ Coder's cloud development environment platform — for developers and agents. Th
 <nuon-banner theme="warn">Waiting on <code>coder_users_templates</code> action. Run it from the Operations tab to populate.</nuon-banner>
 {{ end }}
 
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Recent builds & job queue</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Recent builds & job queue</p>
+  {{ with $bjUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 {{ if $bjReady }}
 {{ $queue := dig "queue" (dict) $bjOut }}
@@ -245,7 +275,10 @@ Coder's cloud development environment platform — for developers and agents. Th
 <nuon-banner theme="warn">Waiting on <code>coder_builds_jobs</code> action. Run it from the Operations tab to populate.</nuon-banner>
 {{ end }}
 
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Provisioners</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Provisioners</p>
+  {{ with $provUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 {{ if $provReady }}
 {{ $daemons := dig "daemons" (list) $provOut }}
@@ -493,7 +526,10 @@ Day-2 actions you can run from here. Each one executes inside your install with 
 </nuon-group>
 
 {{ if and $tfReady (gt $tfCount 0.0) }}
-<p style="font-size:1.05rem; font-weight:700; margin-top:1.25rem; margin-bottom:0.5rem;">Stale templates (90+ days)</p>
+<div style="display:flex; align-items:baseline; gap:0.75rem; margin-top:1.25rem; margin-bottom:0.5rem;">
+  <p style="font-size:1.05rem; font-weight:700; margin:0;">Stale templates (90+ days)</p>
+  {{ with $tfUpdated }}<span style="margin-left:auto; font-size:0.85em; color:#6b7280;">Last updated <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+</div>
 
 <table>
   <thead><tr><th>Template</th><th>Display name</th><th>Stale</th><th>Workspaces</th></tr></thead>

--- a/coder/actions/coder-agents-health.toml
+++ b/coder/actions/coder-agents-health.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-agents-health: running workspaces with disconnected agents"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -79,9 +81,10 @@ if [ "$count" = "0" ]; then ind="🟢"; else ind="🔴"; fi
 
 output=$(jq --null-input -c \
   --arg ind "$ind" \
+  --arg updated_at "$updated_at" \
   --argjson count "$count" \
   --argjson data "$data" \
-  '{indicator: $ind, count: $count, disconnected: $data.disconnected}')
+  '{indicator: $ind, updated_at: $updated_at, count: $count, disconnected: $data.disconnected}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/coder-agents-health.toml
+++ b/coder/actions/coder-agents-health.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-agents-health"
 inline_contents = '''

--- a/coder/actions/coder-builds-jobs.toml
+++ b/coder/actions/coder-builds-jobs.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-builds-jobs: last 10 builds + provisioner_jobs queue (last hour)"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -75,8 +77,9 @@ fi
 
 output=$(jq --null-input -c \
   --arg ind "$ind" \
+  --arg updated_at "$updated_at" \
   --argjson data "$data" \
-  '{indicator: $ind, recent_builds: $data.recent_builds, queue: $data.queue}')
+  '{indicator: $ind, updated_at: $updated_at, recent_builds: $data.recent_builds, queue: $data.queue}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/coder-builds-jobs.toml
+++ b/coder/actions/coder-builds-jobs.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-builds-jobs"
 inline_contents = '''
@@ -31,7 +35,7 @@ SELECT json_build_object(
     SELECT
       w.name AS workspace_name,
       wb.transition,
-      wb.created_at::text AS created_at,
+      to_char(wb.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
       pj.job_status,
       COALESCE(pj.completed_at::text, '') AS completed_at,
       COALESCE(pj.error, '')             AS error

--- a/coder/actions/coder-deployment-health.toml
+++ b/coder/actions/coder-deployment-health.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-deployment-health"
 inline_contents = '''

--- a/coder/actions/coder-deployment-health.toml
+++ b/coder/actions/coder-deployment-health.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-deployment-health: 6-subsystem health matrix"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -77,10 +79,12 @@ if [ "$reds" -gt 0 ]; then overall="🔴"; else overall="🟢"; fi
 
 output=$(jq --null-input -c \
   --arg ind "$overall" \
+  --arg updated_at "$updated_at" \
   --arg access "$access" --arg database "$database" --arg provisioner "$provisioner" \
   --arg derp "$derp" --arg websocket "$websocket" --arg proxy "$proxy" \
   --arg access_http "$access_http" --arg derp_http "$derp_http" --arg ws_http "$ws_http" \
   '{indicator: $ind,
+    updated_at: $updated_at,
     subsystems: {
       access_url: $access,
       database: $database,

--- a/coder/actions/coder-health.toml
+++ b/coder/actions/coder-health.toml
@@ -26,13 +26,16 @@ http=$(curl --silent --show-error --max-time 30 --retry 3 --retry-delay 5 \
   -o "$tmp" -w '%{http_code}' "$url")
 body=$(cat "$tmp")
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 if [ "$http" != "200" ]; then
   indicator="🔴"
   rc=1
   output=$(jq --null-input -c \
     --arg indicator "$indicator" --arg url "$url" \
+    --arg updated_at "$updated_at" \
     --arg http "$http" --arg body "$body" \
-    '{indicator: $indicator, url: $url, http_code: $http, body: $body}')
+    '{indicator: $indicator, updated_at: $updated_at, url: $url, http_code: $http, body: $body}')
 else
   version=$(echo    "$body" | jq -r '.version       // "unknown"')
   deployment=$(echo "$body" | jq -r '.deployment_id // null')
@@ -44,8 +47,9 @@ else
   fi
   output=$(jq --null-input -c \
     --arg indicator "$indicator" --arg url "$url" \
+    --arg updated_at "$updated_at" \
     --arg version "$version" --arg deployment "$deployment" --arg dashboard "$dashboard" \
-    '{indicator: $indicator, url: $url,
+    '{indicator: $indicator, updated_at: $updated_at, url: $url,
       version: $version, deployment_id: $deployment, dashboard_url: $dashboard}')
 fi
 

--- a/coder/actions/coder-health.toml
+++ b/coder/actions/coder-health.toml
@@ -7,6 +7,10 @@ enable_kube_config = false
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-health"
 inline_contents = '''

--- a/coder/actions/coder-healthcheck.toml
+++ b/coder/actions/coder-healthcheck.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name    = "alb-healthcheck"
 command = "./healthcheck.sh"
@@ -14,7 +18,7 @@ command = "./healthcheck.sh"
 [steps.public_repo]
 repo      = "nuonco/example-app-configs"
 directory = "coder/src/actions/alb"
-branch    = "mm/coder-runbook-timestamps"
+branch    = "main"
 
 [steps.env_vars]
 INGRESS_NAME              = "{{.nuon.install.id}}-public"

--- a/coder/actions/coder-healthcheck.toml
+++ b/coder/actions/coder-healthcheck.toml
@@ -14,7 +14,7 @@ command = "./healthcheck.sh"
 [steps.public_repo]
 repo      = "nuonco/example-app-configs"
 directory = "coder/src/actions/alb"
-branch    = "main"
+branch    = "mm/coder-runbook-timestamps"
 
 [steps.env_vars]
 INGRESS_NAME              = "{{.nuon.install.id}}-public"

--- a/coder/actions/coder-provisioners.toml
+++ b/coder/actions/coder-provisioners.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-provisioners"
 inline_contents = '''

--- a/coder/actions/coder-provisioners.toml
+++ b/coder/actions/coder-provisioners.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-provisioners: SELECT from provisioner_daemons via $DB_SECRET_NAME"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -58,10 +60,11 @@ fi
 
 output=$(jq --null-input -c \
   --arg ind "$ind" \
+  --arg updated_at "$updated_at" \
   --argjson data "$data" \
   --argjson total "$total" \
   --argjson healthy "$healthy" \
-  '{indicator: $ind, total: $total, healthy: $healthy, daemons: $data}')
+  '{indicator: $ind, updated_at: $updated_at, total: $total, healthy: $healthy, daemons: $data}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/coder-template-freshness.toml
+++ b/coder/actions/coder-template-freshness.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-template-freshness"
 inline_contents = '''

--- a/coder/actions/coder-template-freshness.toml
+++ b/coder/actions/coder-template-freshness.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-template-freshness: templates not updated in 90+ days"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -54,9 +56,10 @@ if [ "$count" = "0" ]; then ind="🟢"; else ind="🟡"; fi
 
 output=$(jq --null-input -c \
   --arg ind "$ind" \
+  --arg updated_at "$updated_at" \
   --argjson count "$count" \
   --argjson stale "$data" \
-  '{indicator: $ind, count: $count, stale: $stale}')
+  '{indicator: $ind, updated_at: $updated_at, count: $count, stale: $stale}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/coder-users-templates.toml
+++ b/coder/actions/coder-users-templates.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-users-templates"
 inline_contents = '''

--- a/coder/actions/coder-users-templates.toml
+++ b/coder/actions/coder-users-templates.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-users-templates: user counts + template list with workspace counts"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -62,8 +64,9 @@ if [ "$user_total" != "0" ] && [ "$tpl_count" != "0" ]; then ind="🟢"; else in
 
 output=$(jq --null-input -c \
   --arg ind "$ind" \
+  --arg updated_at "$updated_at" \
   --argjson data "$data" \
-  '{indicator: $ind, users: $data.users, templates: $data.templates}')
+  '{indicator: $ind, updated_at: $updated_at, users: $data.users, templates: $data.templates}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/coder-workspaces.toml
+++ b/coder/actions/coder-workspaces.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "coder-workspaces"
 inline_contents = '''
@@ -62,7 +66,8 @@ joined AS (
 SELECT json_build_object(
   'counts',  COALESCE((SELECT json_object_agg(status, c) FROM (SELECT status, COUNT(*) AS c FROM joined GROUP BY status) s), '{}'::json),
   'recent', COALESCE((SELECT json_agg(row_to_json(r)) FROM (
-              SELECT name, status, last_used_at::text AS last_used_at
+              SELECT name, status,
+                     to_char(last_used_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS last_used_at
               FROM joined
               WHERE status != 'deleted'
               ORDER BY last_used_at DESC NULLS LAST

--- a/coder/actions/coder-workspaces.toml
+++ b/coder/actions/coder-workspaces.toml
@@ -16,10 +16,12 @@ set -u
 
 echo "==> coder-workspaces: workspaces grouped by latest-build status"
 
+updated_at="$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)"
+
 url=$(kubectl get secret "$DB_SECRET_NAME" -n "$CODER_NAMESPACE" \
   -o jsonpath='{.data.url}' 2>/dev/null | base64 -d 2>/dev/null || true)
 if [ -z "$url" ]; then
-  echo '{"indicator":"🔴","error":"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+  jq -nc --arg updated_at "$updated_at" '{indicator:"🔴", updated_at:$updated_at, error:"secret-empty"}' >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
   exit 1
 fi
 
@@ -88,10 +90,11 @@ fi
 
 output=$(jq --null-input -c \
   --arg ind "$ind" \
+  --arg updated_at "$updated_at" \
   --argjson data "$data" \
   --argjson total "$total" \
   --argjson failed "$failed" \
-  '{indicator: $ind, total_active: $total, failed: $failed, counts: $data.counts, recent: $data.recent}')
+  '{indicator: $ind, updated_at: $updated_at, total_active: $total, failed: $failed, counts: $data.counts, recent: $data.recent}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/db-ping.toml
+++ b/coder/actions/db-ping.toml
@@ -48,11 +48,12 @@ fi
 
 output=$(jq --null-input -c \
   --arg indicator "$indicator" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
   --arg secret    "$DB_SECRET_NAME" \
   --arg namespace "$CODER_NAMESPACE" \
   --argjson elapsed_s "$elapsed_s" \
   --arg raw "$result" \
-  '{indicator: $indicator, namespace: $namespace, secret: $secret, elapsed_s: $elapsed_s, raw: $raw}')
+  '{indicator: $indicator, updated_at: $updated_at, namespace: $namespace, secret: $secret, elapsed_s: $elapsed_s, raw: $raw}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/db-ping.toml
+++ b/coder/actions/db-ping.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "db-ping"
 inline_contents = '''

--- a/coder/actions/grafana-health.toml
+++ b/coder/actions/grafana-health.toml
@@ -7,6 +7,10 @@ enable_kube_config = false
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "grafana-health"
 inline_contents = '''

--- a/coder/actions/grafana-health.toml
+++ b/coder/actions/grafana-health.toml
@@ -34,10 +34,11 @@ fi
 
 output=$(jq --null-input -c \
   --arg indicator "$indicator" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
   --arg url       "$url" \
   --arg database  "$database" \
   --arg version   "$version" \
-  '{indicator: $indicator, url: $url, database: $database, version: $version}')
+  '{indicator: $indicator, updated_at: $updated_at, url: $url, database: $database, version: $version}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/actions/k8s-status.toml
+++ b/coder/actions/k8s-status.toml
@@ -81,6 +81,7 @@ fi
 
 output=$(jq --null-input -c \
   --arg indicator "$indicator" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
   --argjson nodes_total "$nodes_total" \
   --argjson nodes_ready "$nodes_ready" \
   --argjson coder_pods "$coder_pods" \
@@ -89,6 +90,7 @@ output=$(jq --null-input -c \
   --argjson obs_deploys "$obs_deploys" \
   '{
     indicator: $indicator,
+    updated_at: $updated_at,
     nodes: {total: $nodes_total, ready: $nodes_ready},
     pods: [$coder_pods, $obs_pods],
     deployments: [$coder_deploys, $obs_deploys]

--- a/coder/actions/k8s-status.toml
+++ b/coder/actions/k8s-status.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "k8s-status"
 inline_contents = '''

--- a/coder/actions/prom-targets.toml
+++ b/coder/actions/prom-targets.toml
@@ -7,6 +7,10 @@ enable_kube_config = true
 [[triggers]]
 type = "manual"
 
+[[triggers]]
+type          = "cron"
+cron_schedule = "0,30 * * * *"
+
 [[steps]]
 name = "prom-targets"
 inline_contents = '''

--- a/coder/actions/prom-targets.toml
+++ b/coder/actions/prom-targets.toml
@@ -50,11 +50,12 @@ fi
 
 output=$(jq --null-input -c \
   --arg indicator "$indicator" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
   --arg pod "$pod" \
   --argjson total "$total" \
   --argjson up "$up" \
   --argjson down "$down" \
-  '{indicator: $indicator, pod: $pod, total: $total, up: $up, down: $down}')
+  '{indicator: $indicator, updated_at: $updated_at, pod: $pod, total: $total, up: $up, down: $down}')
 
 echo "$output" | jq .
 echo "$output" >> "$NUON_ACTIONS_OUTPUT_FILEPATH"

--- a/coder/inputs.toml
+++ b/coder/inputs.toml
@@ -8,7 +8,7 @@ display_name = "Coder Configurations"
 [[input]]
 name         = "release"
 description  = "The release of Coder to deploy."
-default      = "v2.31.1"
+default      = "v2.34.2"
 display_name = "Release"
 internal     = true
 group        = "coder"

--- a/coder/src/actions/alb/healthcheck.sh
+++ b/coder/src/actions/alb/healthcheck.sh
@@ -40,7 +40,7 @@ else
 fi
 
 # compose the output
-outputs=$(jq --null-input \
+outputs=$(jq --null-input -c \
   --arg coder_cert "$coder_cert" \
   --arg coder_hn "$coder_hostname" \
   --arg coder_ind "$coder_indicator" \
@@ -48,7 +48,9 @@ outputs=$(jq --null-input \
   --arg grafana_hn "$grafana_hostname" \
   --arg grafana_ind "$grafana_indicator" \
   --argjson grafana_status "$grafana_status" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
   '{
+    "updated_at": $updated_at,
     "coder": {"status": $coder_status, "indicator": $coder_ind, "certificate_arn": $coder_cert, "hostname": $coder_hn},
     "grafana": {"status": $grafana_status, "indicator": $grafana_ind, "hostname": $grafana_hn}
   }')


### PR DESCRIPTION
Polish pass on the Coder install README plus auto-refreshing tiles.

- Cron triggers (0,30 * * * *) on the 13 runbook actions so tiles refresh every 30 min without manual runs; manual `Run runbook` still works
- Fix Recently active workspaces / Recent builds "Started" columns rendering blank — Postgres `::text` cast emitted non-ISO strings; use `to_char` with explicit ISO format
- Configuration tab tables render live install values via `{{ .nuon.install.inputs.<name> }}` instead of static defaults
- README structure: Install healthcheck → Platform health (with 7-row breakdown), Deployment health → Coder control plane health, Observability → Grafana, Operations → Upgrade Coder (4-step rewrite pointing at Current inputs); drop Troubleshooting tab and About this install section; split Users & templates into two sections
- Flip `coder-healthcheck.toml` `[steps.public_repo].branch` back to `main`
- Bump `release` input default to `v2.34.2`