### PR TITLE
chore: change deprecated runbook deploy step type to component_deploy

### DIFF
--- a/aws-lambda/runbooks/deploy_all.toml
+++ b/aws-lambda/runbooks/deploy_all.toml
@@ -4,25 +4,25 @@ readme      = "./runbooks/deploy_all.md"
 
 [[steps]]
 name           = "Deploy Docker image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "docker_image"
 
 [[steps]]
 name           = "Deploy DynamoDB table"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "dynamodb_table"
 
 [[steps]]
 name           = "Deploy Lambda function"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "lambda_function"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy API Gateway"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "api_gateway"

--- a/aws-lambda/runbooks/deploy_and_verify.toml
+++ b/aws-lambda/runbooks/deploy_and_verify.toml
@@ -4,27 +4,27 @@ readme      = "./runbooks/deploy_and_verify.md"
 
 [[steps]]
 name           = "Deploy Docker image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "docker_image"
 
 [[steps]]
 name           = "Deploy DynamoDB table"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "dynamodb_table"
 
 [[steps]]
 name           = "Deploy Lambda function"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "lambda_function"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy API Gateway"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "api_gateway"
 
 [[steps]]

--- a/ecs-simple/runbooks/deploy_all.toml
+++ b/ecs-simple/runbooks/deploy_all.toml
@@ -4,25 +4,25 @@ readme      = "./runbooks/deploy_all.md"
 
 [[steps]]
 name           = "Deploy container image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_whoami"
 
 [[steps]]
 name           = "Deploy ECS cluster"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "cluster"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy ECS service"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "whoami"
 
 [[steps]]
 name           = "Deploy ALB"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "alb"

--- a/ecs-simple/runbooks/deploy_and_verify.toml
+++ b/ecs-simple/runbooks/deploy_and_verify.toml
@@ -4,27 +4,27 @@ readme      = "./runbooks/deploy_and_verify.md"
 
 [[steps]]
 name           = "Deploy container image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_whoami"
 
 [[steps]]
 name           = "Deploy ECS cluster"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "cluster"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy ECS service"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "whoami"
 
 [[steps]]
 name           = "Deploy ALB"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "alb"
 
 [[steps]]

--- a/ecs-simple/runbooks/deploy_verify_and_restart.toml
+++ b/ecs-simple/runbooks/deploy_verify_and_restart.toml
@@ -4,27 +4,27 @@ readme      = "./runbooks/deploy_verify_and_restart.md"
 
 [[steps]]
 name           = "Deploy container image"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "img_whoami"
 
 [[steps]]
 name           = "Deploy ECS cluster"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "cluster"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy ECS service"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "whoami"
 
 [[steps]]
 name           = "Deploy ALB"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "alb"
 
 [[steps]]

--- a/eks-simple/runbooks/deploy_all.toml
+++ b/eks-simple/runbooks/deploy_all.toml
@@ -4,15 +4,15 @@ readme      = "./runbooks/deploy_all.md"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy whoami"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "whoami"
 
 [[steps]]
 name           = "Deploy ALB"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "application_load_balancer"

--- a/eks-simple/runbooks/deploy_and_verify.toml
+++ b/eks-simple/runbooks/deploy_and_verify.toml
@@ -4,17 +4,17 @@ readme      = "./runbooks/deploy_and_verify.md"
 
 [[steps]]
 name           = "Deploy certificate"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "certificate"
 
 [[steps]]
 name           = "Deploy whoami"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "whoami"
 
 [[steps]]
 name           = "Deploy ALB"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "application_load_balancer"
 
 [[steps]]

--- a/httpbin/runbooks/deploy_and_verify.toml
+++ b/httpbin/runbooks/deploy_and_verify.toml
@@ -4,7 +4,7 @@ readme      = "./runbooks/deploy_and_verify.md"
 
 [[steps]]
 name           = "Deploy EC2 instance"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "ec2"
 
 [[steps]]

--- a/httpbin/runbooks/deploy_verify_and_logs.toml
+++ b/httpbin/runbooks/deploy_verify_and_logs.toml
@@ -4,7 +4,7 @@ readme      = "./runbooks/deploy_verify_and_logs.md"
 
 [[steps]]
 name           = "Deploy EC2 instance"
-type           = "deploy"
+type           = "component_deploy"
 component_name = "ec2"
 
 [[steps]]


### PR DESCRIPTION
Fix these deprecation warnings:

```
 deprecated: runbook "deploy_and_verify" step "Deploy EC2 instance": type 'deploy' is deprecated, use 'component_deploy' instead
 deprecated: runbook "deploy_verify_and_logs" step "Deploy EC2 instance": type 'deploy' is deprecated, use 'component_deploy' instead
```