### PR TITLE
fix: no op to coder components

### DIFF
--- a/coder/components/0-rds_subnet.toml
+++ b/coder/components/0-rds_subnet.toml
@@ -3,6 +3,7 @@ name              = "rds_subnet"
 type              = "terraform_module"
 terraform_version = "1.13.5"
 max_auto_retries = 5
+skip_noops        = true
 
 [public_repo]
 repo      = "nuonco/components"

--- a/coder/components/1-rds_cluster_coder.toml
+++ b/coder/components/1-rds_cluster_coder.toml
@@ -4,6 +4,7 @@ type              = "terraform_module"
 terraform_version = "1.13.5"
 dependencies      = ["rds_subnet"]
 max_auto_retries = 5
+skip_noops        = true
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/coder/components/2-coder.toml
+++ b/coder/components/2-coder.toml
@@ -7,6 +7,7 @@ namespace      = "coder"
 storage_driver = "configmap"
 dependencies   = ["rds_cluster_coder"]
 max_auto_retries = 5
+skip_noops       = true
 
 [helm_repo]
 repo_url = "https://helm.coder.com/v2"

--- a/coder/components/3-certificate.toml
+++ b/coder/components/3-certificate.toml
@@ -4,6 +4,7 @@ name              = "certificate"
 type              = "terraform_module"
 terraform_version = "1.13.5"
 max_auto_retries = 5
+skip_noops        = true
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/coder/components/4-alb.toml
+++ b/coder/components/4-alb.toml
@@ -6,6 +6,7 @@ chart_name      = "application-load-balancer"
 storage_driver  = "configmap"
 dependencies    = ["coder", "certificate"]
 max_auto_retries = 5
+skip_noops       = true
 
 [public_repo]
 repo      = "nuonco/example-app-configs"

--- a/coder/components/5-kubelogstream.toml
+++ b/coder/components/5-kubelogstream.toml
@@ -5,6 +5,7 @@ namespace      = "coder"
 storage_driver = "configmap"
 dependencies   = ["coder", "application_load_balancer"]
 max_auto_retries = 5
+skip_noops       = true
 
 [helm_repo]
 repo_url = "https://helm.coder.com/logstream-kube"

--- a/coder/components/6-observability.toml
+++ b/coder/components/6-observability.toml
@@ -5,6 +5,7 @@ namespace      = "coder-observability"
 storage_driver = "configmap"
 dependencies   = ["coder", "application_load_balancer"]
 max_auto_retries = 5
+skip_noops       = true
 
 [helm_repo]
 repo_url = "https://helm.coder.com/observability"

--- a/coder/sandbox.toml
+++ b/coder/sandbox.toml
@@ -1,6 +1,7 @@
 # sandbox
 
 terraform_version = "1.13.5"
+skip_noops        = true
 
 [public_repo]
 directory = "."


### PR DESCRIPTION
to shorten Coder upgrade release cycles, adding no-op config to each component so downstream dependent components will skip.

https://docs.nuon.co/updates/035-runbooks-and-readmes#skip-no-op-deploys-and-auto-approve-on-passing-policies