### PR TITLE
feat(eks-simple): make application_load_balancer toggleable

### DIFF
--- a/eks-simple/components/alb.toml
+++ b/eks-simple/components/alb.toml
@@ -5,6 +5,8 @@ type         = "helm_chart"
 chart_name   = "application-load-balancer"
 dependencies = ["whoami"]
 max_auto_retries = 5
+toggleable        = true
+default_enabled   = true
 
 [public_repo]
 repo      = "nuonco/example-app-configs"


### PR DESCRIPTION
## What

Marks the `application_load_balancer` component in `eks-simple` as toggleable, enabled by default.

```toml
toggleable      = true
default_enabled = true
```

## Why

`eks-simple` is the canonical demo config and the ALB is a clean toggle candidate:

- It's a **leaf** — nothing depends on it, so it can be enabled/disabled without tripping the enablement validation rules (enable-requires-deps-enabled / disable-requires-dependents-disabled).
- It maps to a genuinely optional feature: public ingress for the `whoami` workload. Disabling it tears down public access while leaving the rest of the install intact.

`default_enabled = true` preserves current behavior — existing/new installs still get the ALB unless a user explicitly disables it.

## Dependency shape

```
certificate ─┐
             ├─▶ application_load_balancer   (leaf — now toggleable)
whoami ──────┘
```