### PR TITLE
feat: white-label runner API via proxy for gcp-gcs-static-site

### DIFF
--- a/gcp-gcs-static-site/runner.toml
+++ b/gcp-gcs-static-site/runner.toml
@@ -1,3 +1,5 @@
 runner_type = "gcp"
 helm_driver = "configmap"
-init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/tags/gcp-v0.1.4/scripts/gcp/init.sh"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/main/scripts/gcp/init-mng-v2.sh"
+runner_api_url  = "https://runner-api-proxy.prod.nuon.co"
+public_api_url  = "https://runner-api-proxy.prod.nuon.co"

--- a/gcp-gcs-static-site/runner.toml
+++ b/gcp-gcs-static-site/runner.toml
@@ -1,5 +1,3 @@
 runner_type = "gcp"
 helm_driver = "configmap"
-init_script_url = "https://raw.githubusercontent.com/nuonco/runner/main/scripts/gcp/init-mng-v2.sh"
-runner_api_url  = "https://runner-api-proxy.prod.nuon.co"
-public_api_url  = "https://runner-api-proxy.prod.nuon.co"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/tags/gcp-v0.1.4/scripts/gcp/init.sh"

--- a/gcp-gcs-static-site/sandbox.toml
+++ b/gcp-gcs-static-site/sandbox.toml
@@ -7,5 +7,5 @@ branch    = "main"
 
 [vars]
 enable_nuon_dns      = "true"
-public_root_domain   = "{{ .nuon.inputs.inputs.domain }}"
-internal_root_domain = "internal.{{ .nuon.inputs.inputs.domain }}"
+public_root_domain   = "{{ .nuon.install.id }}.{{ .nuon.inputs.inputs.domain }}"
+internal_root_domain = "internal.{{ .nuon.install.id }}.{{ .nuon.inputs.inputs.domain }}"


### PR DESCRIPTION
points runner_api_url + public_api_url at the runner-api-proxy; sandbox uses install ID-scoped DNS so each install gets a unique zone