### PR TITLE
fix: use install_id for cdn resource names instead of project_id

### DIFF
--- a/gcp-gcs-static-site/components/2-tf-cdn.toml
+++ b/gcp-gcs-static-site/components/2-tf-cdn.toml
@@ -12,4 +12,5 @@ branch    = "main"
 [vars]
 bucket_name = "{{.nuon.components.gcs_bucket.outputs.bucket_name}}"
 project_id  = "{{.nuon.install_stack.outputs.project_id}}"
+install_id  = "{{.nuon.install.id}}"
 domain      = "{{.nuon.inputs.inputs.sub_domain}}.{{.nuon.inputs.inputs.domain}}"

--- a/gcp-gcs-static-site/src/components/cdn/main.tf
+++ b/gcp-gcs-static-site/src/components/cdn/main.tf
@@ -1,24 +1,24 @@
 resource "google_compute_backend_bucket" "site" {
-  name        = "static-site-backend-${var.project_id}"
+  name        = "static-site-backend-${var.install_id}"
   bucket_name = var.bucket_name
   project     = var.project_id
   enable_cdn  = true
 }
 
 resource "google_compute_url_map" "site" {
-  name            = "static-site-${var.project_id}"
+  name            = "static-site-${var.install_id}"
   project         = var.project_id
   default_service = google_compute_backend_bucket.site.id
 }
 
 resource "google_compute_target_http_proxy" "site" {
-  name    = "static-site-proxy-${var.project_id}"
+  name    = "static-site-proxy-${var.install_id}"
   project = var.project_id
   url_map = google_compute_url_map.site.id
 }
 
 resource "google_compute_global_forwarding_rule" "site" {
-  name       = "static-site-fwd-${var.project_id}"
+  name       = "static-site-fwd-${var.install_id}"
   project    = var.project_id
   target     = google_compute_target_http_proxy.site.id
   port_range = "80"

--- a/gcp-gcs-static-site/src/components/cdn/variables.tf
+++ b/gcp-gcs-static-site/src/components/cdn/variables.tf
@@ -6,6 +6,10 @@ variable "project_id" {
   type = string
 }
 
+variable "install_id" {
+  type = string
+}
+
 variable "domain" {
   type = string
 }


### PR DESCRIPTION
project_id-based names conflict when multiple installs share the same GCP project; install_id is always unique