### PR TITLE
fix: coder breakglass config and labels

### DIFF
--- a/coder/actions/coder-agents-health.toml
+++ b/coder/actions/coder-agents-health.toml
@@ -3,6 +3,7 @@
 name    = "coder_agents_health"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-builds-jobs.toml
+++ b/coder/actions/coder-builds-jobs.toml
@@ -3,6 +3,7 @@
 name    = "coder_builds_jobs"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-deployment-health.toml
+++ b/coder/actions/coder-deployment-health.toml
@@ -3,6 +3,7 @@
 name    = "coder_deployment_health"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-health.toml
+++ b/coder/actions/coder-health.toml
@@ -3,6 +3,7 @@
 name    = "coder_health"
 timeout = "5m"
 enable_kube_config = false
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-healthcheck.toml
+++ b/coder/actions/coder-healthcheck.toml
@@ -3,6 +3,7 @@
 name    = "alb_healthcheck"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "alb", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-provisioners.toml
+++ b/coder/actions/coder-provisioners.toml
@@ -3,6 +3,7 @@
 name    = "coder_provisioners"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-template-freshness.toml
+++ b/coder/actions/coder-template-freshness.toml
@@ -3,6 +3,7 @@
 name    = "coder_template_freshness"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-users-templates.toml
+++ b/coder/actions/coder-users-templates.toml
@@ -3,6 +3,7 @@
 name    = "coder_users_templates"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder-workspaces.toml
+++ b/coder/actions/coder-workspaces.toml
@@ -3,6 +3,7 @@
 name    = "coder_workspaces"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "coder", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/coder_rds_creds.toml
+++ b/coder/actions/coder_rds_creds.toml
@@ -2,6 +2,7 @@
 name    = "coder_rds_creds"
 timeout = "1m"
 enable_kube_config = true
+labels  = { service = "rds", type = "step" }
 
 [[triggers]]
 type           = "post-deploy-component"

--- a/coder/actions/db-ping.toml
+++ b/coder/actions/db-ping.toml
@@ -3,6 +3,7 @@
 name    = "db_ping"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "rds", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/grafana-health.toml
+++ b/coder/actions/grafana-health.toml
@@ -3,6 +3,7 @@
 name    = "grafana_health"
 timeout = "5m"
 enable_kube_config = false
+labels  = { service = "grafana", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/grafana-password.toml
+++ b/coder/actions/grafana-password.toml
@@ -1,6 +1,7 @@
 name    = "grafana_password"
 timeout = "1m"
 enable_kube_config = false
+labels  = { service = "grafana", type = "tool" }
 
 [[triggers]]
 type = "manual"

--- a/coder/actions/grafana-setup.toml
+++ b/coder/actions/grafana-setup.toml
@@ -1,6 +1,7 @@
 name    = "grafana_setup"
 timeout = "2m"
 enable_kube_config = true
+labels  = { service = "grafana", type = "setup" }
 
 [[triggers]]
 type           = "pre-deploy-component"

--- a/coder/actions/k8s-clean-failed-pods.toml
+++ b/coder/actions/k8s-clean-failed-pods.toml
@@ -1,0 +1,35 @@
+name    = "k8s_clean_failed_pods"
+timeout = "5m"
+enable_kube_config = true
+break_glass_role = "{{.nuon.install.id}}-coder-sandbox-break-glass"
+labels  = { service = "kubernetes", type = "break-glass" }
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "clean-failed-pods"
+inline_contents = '''
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "==> k8s_clean_failed_pods: $NAMESPACES"
+
+per_ns='[]'
+for ns in $NAMESPACES; do
+  n=$(kubectl delete pod -n "$ns" \
+    --field-selector=status.phase=Failed --ignore-not-found -o name | wc -l | tr -d ' ')
+  echo "==> $ns: deleted $n failed pods"
+  per_ns=$(echo "$per_ns" | jq -c --arg ns "$ns" --argjson n "$n" '. + [{namespace: $ns, deleted: $n}]')
+done
+
+jq --null-input -c \
+  --argjson namespaces "$per_ns" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
+  '{namespaces: $namespaces, updated_at: $updated_at}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+NAMESPACES = "coder coder-observability"

--- a/coder/actions/k8s-clear-finalizers.toml
+++ b/coder/actions/k8s-clear-finalizers.toml
@@ -1,0 +1,35 @@
+name    = "k8s_clear_finalizers"
+timeout = "5m"
+enable_kube_config = true
+break_glass_role = "{{.nuon.install.id}}-coder-sandbox-break-glass"
+labels  = { service = "kubernetes", type = "break-glass" }
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "clear-finalizers"
+inline_contents = '''
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "==> k8s_clear_finalizers: $KIND/$NAME in $NAMESPACE"
+[ -n "$NAME" ] || { echo "NAME is required" >&2; exit 1; }
+
+kubectl patch "$KIND" "$NAME" -n "$NAMESPACE" \
+  -p '{"metadata":{"finalizers":[]}}' --type=merge
+
+jq --null-input -c \
+  --arg kind "$KIND" \
+  --arg name "$NAME" \
+  --arg namespace "$NAMESPACE" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
+  '{kind: $kind, name: $name, namespace: $namespace, result: "finalizers cleared", updated_at: $updated_at}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+NAMESPACE = "coder"
+KIND      = "ingress"
+NAME      = ""

--- a/coder/actions/k8s-restart-deployment.toml
+++ b/coder/actions/k8s-restart-deployment.toml
@@ -1,0 +1,33 @@
+name    = "k8s_restart_deployment"
+timeout = "10m"
+enable_kube_config = true
+break_glass_role = "{{.nuon.install.id}}-coder-sandbox-break-glass"
+labels  = { service = "kubernetes", type = "break-glass" }
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "restart-deployment"
+inline_contents = '''
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "==> k8s_restart_deployment: deployment/$NAME in $NAMESPACE"
+[ -n "$NAME" ] || { echo "NAME is required" >&2; exit 1; }
+
+kubectl rollout restart "deployment/$NAME" -n "$NAMESPACE"
+kubectl rollout status "deployment/$NAME" -n "$NAMESPACE" --timeout=5m
+
+jq --null-input -c \
+  --arg name "$NAME" \
+  --arg namespace "$NAMESPACE" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
+  '{deployment: $name, namespace: $namespace, result: "restarted", updated_at: $updated_at}' \
+  >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+NAMESPACE = "coder"
+NAME      = ""

--- a/coder/actions/k8s-status.toml
+++ b/coder/actions/k8s-status.toml
@@ -3,6 +3,7 @@
 name    = "k8s_status"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "kubernetes", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/prom-targets.toml
+++ b/coder/actions/prom-targets.toml
@@ -3,6 +3,7 @@
 name    = "prom_targets"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "prometheus", type = "report" }
 
 [[triggers]]
 type          = "cron"

--- a/coder/actions/troubleshoot.toml
+++ b/coder/actions/troubleshoot.toml
@@ -2,6 +2,7 @@
 name    = "troubleshoot"
 timeout = "5m"
 enable_kube_config = true
+labels  = { service = "kubernetes", type = "tool" }
 
 [[triggers]]
 type = "manual"

--- a/coder/break_glass.toml
+++ b/coder/break_glass.toml
@@ -2,7 +2,7 @@
 name                 = "{{.nuon.install.id}}-coder-sandbox-break-glass"
 description          = "grants access to the sandbox for install {{.nuon.install.id}}."
 display_name         = "break glass role"
-permissions_boundary = ""
+permissions_boundary = "./breakglass_boundary.json"
 
 [[role.policies]]
 managed_policy_name = "AdministratorAccess"

--- a/coder/permissions/breakglass_boundary.json
+++ b/coder/permissions/breakglass_boundary.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "cloudwatch:*",
+          "ec2:*",
+          "eks:*",
+          "iam:*",
+          "rds:*",
+          "s3:*",
+          "secretsmanager:*",
+          "sqs:*",
+          "ecr:*",
+          "acm:*",
+          "Route53:*",
+          "kms:*",
+          "organizations:DescribeOrganization"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }

--- a/coder/runbooks/healthcheck_coder.toml
+++ b/coder/runbooks/healthcheck_coder.toml
@@ -3,8 +3,8 @@ description = "Refreshes the Coder data tables on the install README — deploym
 readme      = "./runbooks/healthcheck_coder.md"
 
 [labels]
-team = "platform"
-kind = "refresh"
+service = "coder"
+type    = "report"
 
 [[steps]]
 name        = "coder-deployment-health"

--- a/coder/runbooks/healthcheck_infra.toml
+++ b/coder/runbooks/healthcheck_infra.toml
@@ -3,8 +3,8 @@ description = "End-to-end healthcheck across Kubernetes, Coder, RDS, ALB, Grafan
 readme      = "./runbooks/healthcheck_infra.md"
 
 [labels]
-team = "platform"
-kind = "healthcheck"
+service = "infra"
+type    = "report"
 
 [[steps]]
 name        = "k8s-status"

--- a/coder/sandbox.tfvars
+++ b/coder/sandbox.tfvars
@@ -34,3 +34,24 @@ maintenance_role_eks_access_entry_policy_associations = {
     }
   }
 }
+
+{{ if gt (len .nuon.install_stack.outputs.break_glass_role_arns) 0 }}
+break_glass_iam_role_arn = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"
+
+break_glass_role_eks_kubernetes_groups = []
+
+break_glass_role_eks_access_entry_policy_associations = {
+  cluster_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+{{ end }}


### PR DESCRIPTION
- Fixed k8s_status action failing under break-glass with Unauthorized: the break-glass role wasn't in the cluster — coder/sandbox.tfvars was missing break_glass_iam_role_arn, so it had no EKS access entry. Added it (cluster-admin). Note: If you have an existing install , you need to reprovision the install + sandbox, so it's live.
- Added a break-glass IAM boundary (break_glass.toml + permissions/breakglass_boundary.json).
- Added 3 break-glass actions maintenance can't do: k8s_clear_finalizers, k8s_clean_failed_pods, k8s_restart_deployment.
- Labeled all actions + both runbooks with byoc's service/type convention (break-glass ones tagged type = "break-glass").