### PR TITLE
fix: moved breakglass grank and revoke of eks access entries

### DIFF
--- a/coder/README.md
+++ b/coder/README.md
@@ -66,14 +66,23 @@
 {{ $tfUpdated   := dig "updated_at" "" $tfOut }}
 {{ $agUpdated   := dig "updated_at" "" $agOut }}
 
+{{ $bgGrant  := default dict (index (default dict .nuon.actions.workflows) "break_glass_grant_eks_access") }}
+{{ $bgRevoke := default dict (index (default dict .nuon.actions.workflows) "break_glass_revoke_eks_access") }}
+{{ $bgClean  := default dict (index (default dict .nuon.actions.workflows) "k8s_clean_failed_pods") }}
+{{ $bgGrantUpdated  := dig "updated_at" "" (default dict (dig "outputs" dict $bgGrant)) }}
+{{ $bgRevokeUpdated := dig "updated_at" "" (default dict (dig "outputs" dict $bgRevoke)) }}
+{{ $bgCleanUpdated  := dig "updated_at" "" (default dict (dig "outputs" dict $bgClean)) }}
+
 <div style="display:flex; width:100%; align-items:center; justify-content:space-between; padding-bottom:1rem;">
   <video autoplay loop muted playsinline width="480" height="270">
     <source src="https://coder.together.agency/videos/logo/sections/0/content/9/value/video.mp4" type="video/mp4">
     Your browser does not support the video tag.
   </video>
   <div style="display:flex; flex-direction:column; gap:10px; align-items:flex-end;">
-    <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:#8b5cf6; color:white; border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Coder →</a>
-    <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/grafana" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:transparent; color:#c4b5fd; border:1px solid rgba(139,92,246,0.6); border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Grafana →</a>
+    <div style="display:flex; gap:10px; align-items:center;">
+      <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:#8b5cf6; color:white; border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Coder →</a>
+      <a href="https://{{.nuon.install.sandbox.outputs.nuon_dns.public_domain.name}}/grafana" style="display:inline-flex; align-items:center; justify-content:center; gap:8px; padding:10px 22px; background:transparent; color:#c4b5fd; border:1px solid rgba(139,92,246,0.6); border-radius:8px; text-decoration:none; font-weight:600; font-size:15px;">Open Grafana →</a>
+    </div>
     <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
       <nuon-run-runbook name="healthcheck_infra"></nuon-run-runbook>
       {{ with $promUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
@@ -81,6 +90,18 @@
     <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
       <nuon-run-runbook name="healthcheck_coder"></nuon-run-runbook>
       {{ with $bjUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+    </div>
+    <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
+      <nuon-run-runbook name="breakglass_grant"></nuon-run-runbook>
+      {{ with $bgGrantUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+    </div>
+    <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
+      <nuon-run-runbook name="breakglass_revoke"></nuon-run-runbook>
+      {{ with $bgRevokeUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
+    </div>
+    <div style="display:flex; flex-direction:column; align-items:flex-end; gap:2px;">
+      <nuon-run-runbook name="breakglass_remediate"></nuon-run-runbook>
+      {{ with $bgCleanUpdated }}<span style="font-size:0.75em; color:#6b7280;">Last run <nuon-time time="{{ . }}" format="relative"></nuon-time></span>{{ end }}
     </div>
   </div>
 </div>

--- a/coder/actions/break-glass-grant-access.toml
+++ b/coder/actions/break-glass-grant-access.toml
@@ -1,0 +1,56 @@
+name    = "break_glass_grant_eks_access"
+timeout = "2m"
+break_glass_role = "{{.nuon.install.id}}-coder-sandbox-break-glass"
+labels  = { service = "eks", type = "break-glass" }
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "grant-eks-access"
+inline_contents = '''
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export AWS_PAGER=""
+export AWS_DEFAULT_REGION="$AWS_REGION"
+
+aws sts get-caller-identity | jq -c
+
+created=false
+if aws eks describe-access-entry \
+  --cluster-name "$CLUSTER_NAME" \
+  --principal-arn "$PRINCIPAL_ARN" >/dev/null 2>&1; then
+  echo "==> access entry already exists for $PRINCIPAL_ARN"
+else
+  echo "==> creating access entry for $PRINCIPAL_ARN"
+  aws eks create-access-entry \
+    --cluster-name "$CLUSTER_NAME" \
+    --principal-arn "$PRINCIPAL_ARN" \
+    --type STANDARD
+  created=true
+fi
+
+echo "==> associating $POLICY_ARN (cluster scope)"
+aws eks associate-access-policy \
+  --cluster-name "$CLUSTER_NAME" \
+  --principal-arn "$PRINCIPAL_ARN" \
+  --policy-arn "$POLICY_ARN" \
+  --access-scope type=cluster >/dev/null
+
+jq --null-input -c \
+  --arg principal_arn "$PRINCIPAL_ARN" \
+  --arg cluster "$CLUSTER_NAME" \
+  --arg policy_arn "$POLICY_ARN" \
+  --argjson created "$created" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
+  '{principal_arn: $principal_arn, cluster: $cluster, policy_arn: $policy_arn, created: $created, state: "granted", updated_at: $updated_at}' \
+  > "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CLUSTER_NAME  = "{{ .nuon.install.sandbox.outputs.cluster.name }}"
+AWS_REGION    = "{{ .nuon.install.sandbox.outputs.account.region }}"
+PRINCIPAL_ARN = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"
+POLICY_ARN    = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"

--- a/coder/actions/break-glass-revoke-access.toml
+++ b/coder/actions/break-glass-revoke-access.toml
@@ -1,0 +1,49 @@
+name    = "break_glass_revoke_eks_access"
+timeout = "1m"
+break_glass_role = "{{.nuon.install.id}}-coder-sandbox-break-glass"
+labels  = { service = "eks", type = "break-glass", destructive = "true" }
+
+[[triggers]]
+type = "manual"
+
+[[steps]]
+name = "revoke-eks-access"
+inline_contents = '''
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export AWS_PAGER=""
+export AWS_DEFAULT_REGION="$AWS_REGION"
+
+aws sts get-caller-identity | jq -c
+
+existed=false
+state="not_found"
+if aws eks describe-access-entry \
+  --cluster-name "$CLUSTER_NAME" \
+  --principal-arn "$PRINCIPAL_ARN" >/dev/null 2>&1; then
+  existed=true
+  echo "==> deleting access entry for $PRINCIPAL_ARN"
+  aws eks delete-access-entry \
+    --cluster-name "$CLUSTER_NAME" \
+    --principal-arn "$PRINCIPAL_ARN"
+  state="revoked"
+else
+  echo "==> no access entry found for $PRINCIPAL_ARN, nothing to revoke"
+fi
+
+jq --null-input -c \
+  --arg principal_arn "$PRINCIPAL_ARN" \
+  --arg cluster "$CLUSTER_NAME" \
+  --argjson existed "$existed" \
+  --arg state "$state" \
+  --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
+  '{principal_arn: $principal_arn, cluster: $cluster, existed: $existed, state: $state, updated_at: $updated_at}' \
+  > "$NUON_ACTIONS_OUTPUT_FILEPATH"
+'''
+
+[steps.env_vars]
+CLUSTER_NAME  = "{{ .nuon.install.sandbox.outputs.cluster.name }}"
+AWS_REGION    = "{{ .nuon.install.sandbox.outputs.account.region }}"
+PRINCIPAL_ARN = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"

--- a/coder/actions/k8s-clear-finalizers.toml
+++ b/coder/actions/k8s-clear-finalizers.toml
@@ -14,18 +14,29 @@ inline_contents = '''
 
 set -euo pipefail
 
-echo "==> k8s_clear_finalizers: $KIND/$NAME in $NAMESPACE"
-[ -n "$NAME" ] || { echo "NAME is required" >&2; exit 1; }
+if [ -n "$NAME" ]; then
+  echo "==> k8s_clear_finalizers: $KIND/$NAME in $NAMESPACE"
+  targets="$NAME"
+else
+  echo "==> k8s_clear_finalizers: scanning $KIND in $NAMESPACE for resources stuck Terminating"
+  targets=$(kubectl get "$KIND" -n "$NAMESPACE" -o json \
+    | jq -r '.items[] | select(.metadata.deletionTimestamp != null) | .metadata.name')
+fi
 
-kubectl patch "$KIND" "$NAME" -n "$NAMESPACE" \
-  -p '{"metadata":{"finalizers":[]}}' --type=merge
+cleared='[]'
+for n in $targets; do
+  kubectl patch "$KIND" "$n" -n "$NAMESPACE" \
+    -p '{"metadata":{"finalizers":[]}}' --type=merge
+  echo "==> cleared finalizers on $KIND/$n"
+  cleared=$(echo "$cleared" | jq -c --arg n "$n" '. + [$n]')
+done
 
 jq --null-input -c \
   --arg kind "$KIND" \
-  --arg name "$NAME" \
+  --argjson cleared "$cleared" \
   --arg namespace "$NAMESPACE" \
   --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
-  '{kind: $kind, name: $name, namespace: $namespace, result: "finalizers cleared", updated_at: $updated_at}' \
+  '{kind: $kind, cleared: $cleared, namespace: $namespace, result: "finalizers cleared", updated_at: $updated_at}' \
   >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
 '''
 

--- a/coder/actions/k8s-restart-deployment.toml
+++ b/coder/actions/k8s-restart-deployment.toml
@@ -14,17 +14,28 @@ inline_contents = '''
 
 set -euo pipefail
 
-echo "==> k8s_restart_deployment: deployment/$NAME in $NAMESPACE"
-[ -n "$NAME" ] || { echo "NAME is required" >&2; exit 1; }
+if [ -n "$NAME" ]; then
+  echo "==> k8s_restart_deployment: deployment/$NAME in $NAMESPACE"
+  targets="deployment.apps/$NAME"
+else
+  echo "==> k8s_restart_deployment: all deployments in $NAMESPACE"
+  targets=$(kubectl get deployment -n "$NAMESPACE" -o name | tr '\n' ' ')
+fi
 
-kubectl rollout restart "deployment/$NAME" -n "$NAMESPACE"
-kubectl rollout status "deployment/$NAME" -n "$NAMESPACE" --timeout=5m
+[ -n "$targets" ] || { echo "no deployments found in $NAMESPACE" >&2; exit 1; }
+
+restarted='[]'
+for t in $targets; do
+  kubectl rollout restart "$t" -n "$NAMESPACE"
+  kubectl rollout status "$t" -n "$NAMESPACE" --timeout=5m
+  restarted=$(echo "$restarted" | jq -c --arg t "$t" '. + [$t]')
+done
 
 jq --null-input -c \
-  --arg name "$NAME" \
+  --argjson restarted "$restarted" \
   --arg namespace "$NAMESPACE" \
   --arg updated_at "$(TZ=UTC date +%Y-%m-%dT%H:%M:%SZ)" \
-  '{deployment: $name, namespace: $namespace, result: "restarted", updated_at: $updated_at}' \
+  '{restarted: $restarted, namespace: $namespace, result: "restarted", updated_at: $updated_at}' \
   >> "$NUON_ACTIONS_OUTPUT_FILEPATH"
 '''
 

--- a/coder/runbooks/breakglass_grant.md
+++ b/coder/runbooks/breakglass_grant.md
@@ -1,0 +1,23 @@
+Opens temporary cluster access for the break-glass role. The break-glass role (`{{ .nuon.install.id }}-coder-sandbox-break-glass`) holds `AdministratorAccess` in AWS but has **no standing access to the EKS cluster** — by default it cannot run kubectl against the workload. This runbook creates an EKS access entry for the role and associates `AmazonEKSClusterAdminPolicy` at cluster scope, so the role can operate inside the cluster until access is revoked.
+
+Access is off by default on purpose: the break-glass role only holds cluster-admin while it is explicitly granted, so a disabled or unused role carries no lingering path into the cluster. Push **Run runbook** to grant access. When you are finished, run the `breakglass_revoke` runbook to remove the access entry.
+
+Granting is idempotent — re-running it when access already exists just re-asserts the policy association and is safe.
+
+**Break-glass workflow**
+
+1. Run this runbook to grant access.
+2. Run the Kubernetes break-glass actions below as needed to remediate.
+3. Run the `breakglass_revoke` runbook to close access.
+
+**Break-glass actions**
+
+| Action | What it does |
+|---|---|
+| `break_glass_grant_eks_access`  | Creates the EKS access entry + associates `AmazonEKSClusterAdminPolicy` (this runbook) |
+| `k8s_clean_failed_pods`         | Deletes `Failed` pods in the `coder` and `coder-observability` namespaces |
+| `k8s_clear_finalizers`          | Clears finalizers on `ingress` resources stuck `Terminating` in `coder` (or a single resource if `NAME` is set) |
+| `k8s_restart_deployment`        | Rolling-restarts the `coder`-namespace deployments (or a single one if `NAME` is set) |
+| `break_glass_revoke_eks_access` | Deletes the access entry, removing all cluster access (`breakglass_revoke` runbook) |
+
+Each action can also be run on its own from the Actions list; you do not have to run them through a runbook. All of them run under the break-glass role and require access to be granted first.

--- a/coder/runbooks/breakglass_grant.toml
+++ b/coder/runbooks/breakglass_grant.toml
@@ -1,0 +1,12 @@
+name        = "breakglass_grant"
+description = "Grant the break-glass role temporary EKS cluster-admin by creating an EKS access entry (AmazonEKSClusterAdminPolicy). Access is OFF by default — run this to open it, then run the breakglass_revoke runbook when finished."
+readme      = "./runbooks/breakglass_grant.md"
+
+[labels]
+service = "eks"
+type    = "break-glass"
+
+[[steps]]
+name        = "grant-access"
+type        = "action"
+action_name = "break_glass_grant_eks_access"

--- a/coder/runbooks/breakglass_remediate.md
+++ b/coder/runbooks/breakglass_remediate.md
@@ -1,0 +1,7 @@
+Runs the three Kubernetes break-glass remediations in one pass:
+
+- `k8s_clean_failed_pods` — deletes `Failed` pods in the `coder` and `coder-observability` namespaces
+- `k8s_clear_finalizers` — scans the `coder` namespace for `ingress` resources stuck in `Terminating` and clears their finalizers (or a single resource if `NAME` is set); a safe no-op if nothing is stuck
+- `k8s_restart_deployment` — rolling-restarts the deployments in the `coder` namespace (or a single one if `NAME` is set) and waits for rollout
+
+These run under the break-glass role and need cluster access, so run the `breakglass_grant` runbook first. When you are finished, run `breakglass_revoke` to remove access. Each step can also be run on its own from the Actions list.

--- a/coder/runbooks/breakglass_remediate.toml
+++ b/coder/runbooks/breakglass_remediate.toml
@@ -1,0 +1,22 @@
+name        = "breakglass_remediate"
+description = "Runs the Kubernetes break-glass remediations in sequence — delete failed pods, clear stuck finalizers, rolling-restart the deployment. Requires break-glass access: run the breakglass_grant runbook first and breakglass_revoke when done."
+readme      = "./runbooks/breakglass_remediate.md"
+
+[labels]
+service = "kubernetes"
+type    = "break-glass"
+
+[[steps]]
+name        = "clean-failed-pods"
+type        = "action"
+action_name = "k8s_clean_failed_pods"
+
+[[steps]]
+name        = "clear-finalizers"
+type        = "action"
+action_name = "k8s_clear_finalizers"
+
+[[steps]]
+name        = "restart-deployment"
+type        = "action"
+action_name = "k8s_restart_deployment"

--- a/coder/runbooks/breakglass_revoke.md
+++ b/coder/runbooks/breakglass_revoke.md
@@ -1,0 +1,5 @@
+Closes break-glass cluster access. This deletes the EKS access entry for the break-glass role (`{{ .nuon.install.id }}-coder-sandbox-break-glass`), which also removes its associated `AmazonEKSClusterAdminPolicy`. After this runs, the role keeps its AWS `AdministratorAccess` but can no longer operate inside the EKS cluster.
+
+Push **Run runbook** when you are finished with a break-glass session. It is safe to run at any time — if no access entry exists, it is a no-op and reports `not_found`.
+
+Run the `breakglass_grant` runbook to open access again.

--- a/coder/runbooks/breakglass_revoke.toml
+++ b/coder/runbooks/breakglass_revoke.toml
@@ -1,0 +1,12 @@
+name        = "breakglass_revoke"
+description = "Revoke the break-glass role's EKS access by deleting its access entry, leaving the role with no standing cluster access. Safe to run even if access was never granted."
+readme      = "./runbooks/breakglass_revoke.md"
+
+[labels]
+service = "eks"
+type    = "break-glass"
+
+[[steps]]
+name        = "revoke-access"
+type        = "action"
+action_name = "break_glass_revoke_eks_access"

--- a/coder/sandbox.tfvars
+++ b/coder/sandbox.tfvars
@@ -34,24 +34,3 @@ maintenance_role_eks_access_entry_policy_associations = {
     }
   }
 }
-
-{{ if gt (len .nuon.install_stack.outputs.break_glass_role_arns) 0 }}
-break_glass_iam_role_arn = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"
-
-break_glass_role_eks_kubernetes_groups = []
-
-break_glass_role_eks_access_entry_policy_associations = {
-  cluster_admin = {
-    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
-    access_scope = {
-      type = "cluster"
-    }
-  }
-  eks_admin = {
-    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
-    access_scope = {
-      type = "cluster"
-    }
-  }
-}
-{{ end }}


### PR DESCRIPTION
- Removed the standing break_glass_iam_role_arn block from sandbox.tfvars so the break-glass role has no cluster access by default
- Added break_glass_grant_eks_access / break_glass_revoke_eks_access actions (run under the break-glass role) that create/associate and delete the EKS access entry via the AWS API — access is granted only while explicitly opened, matching the "removed when disabled" model
- Added three runbooks: breakglass_grant, breakglass_revoke, and breakglass_remediate (runs the three kubectl break-glass actions in sequence); surfaced as Run widgets in the install README header alongside the healthchecks
- Fixed k8s_restart_deployment and k8s_clear_finalizers, which required a NAME env var that can't be supplied on a manual/runbook run — empty NAME now targets all coder deployments / only stuck-Terminating ingresses respectively, and still accepts a single NAME when set
- README: Open Coder / Open Grafana now share one row to save vertical space

Note after merge: reprovision the sandbox once so the previously-applied standing access entry is removed; from then on grant/revoke own it.