### PR TITLE
ci: app sync workflows with per-environment

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,80 @@
+# Sync workflows
+
+`sync-app.yaml` and `sync-all-apps.yaml` sync app configs to a Nuon API using a
+per-environment [GitHub Environment](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment)
+secret named `NUON_CONFIG`.
+
+- `sync-app.yaml` runs on PRs (against the `stage` environment) and on pushes to
+  `main` (against the `prod` environment).
+- `sync-all-apps.yaml` is dispatched manually (or on schedule) and lets you pick
+  the environment, ref, and an optional subset of apps.
+
+Each job selects a GitHub Environment and reads `secrets.NUON_CONFIG` from it,
+writing the value to `$HOME/.nuon` before running `nuon apps sync`.
+
+## Adding a new environment
+
+The `NUON_CONFIG` secret is the full `~/.nuon` YAML config, and its `api_token`
+**must be an org-admin token minted from the environment's admin API** — a normal
+`nuon auth login` user token is not sufficient for syncing apps org-wide.
+
+1. Reach the environment's admin API. It is internal, so port-forward it (example
+   for stage; swap `stage` for the target environment):
+
+   ```sh
+   kubectl --context <env-cluster> -n ctl-api \
+     port-forward svc/ctl-api-<env>-admin 8082:80
+   ```
+
+2. Ensure the org admin service account exists, then mint a long-lived token
+   (admin calls are authorized by the `X-Nuon-Admin-Email` header):
+
+   ```sh
+   ADMIN_API_URL="http://localhost:8082"
+   ORG_ID="org_xxxxxxxxxxxxxxxxxxxxxxxx"
+   ADMIN_EMAIL="you@nuon.co"
+
+   curl -sS -X POST "${ADMIN_API_URL}/v1/orgs/${ORG_ID}/admin-service-account" \
+     -H "Content-Type: application/json" \
+     -H "X-Nuon-Admin-Email: ${ADMIN_EMAIL}" \
+     -d '{}'
+
+   curl -sS -X POST "${ADMIN_API_URL}/v1/general/admin-static-token" \
+     -H "Content-Type: application/json" \
+     -H "X-Nuon-Admin-Email: ${ADMIN_EMAIL}" \
+     -d "{\"email_or_subject\": \"${ORG_ID}-admin-service-account\", \"duration\": \"8760h\"}"
+   ```
+
+   The second call returns `{"api_token": "..."}`.
+
+3. Assemble the `~/.nuon` config for the environment:
+
+   ```yaml
+   api_url: https://api.<env>.nuon.co
+   org_id: org_xxxxxxxxxxxxxxxxxxxxxxxx
+   api_token: <api_token from step 2>
+   ```
+
+4. Create the GitHub Environment (repo **Settings → Environments → New
+   environment**), naming it to match the value used in the workflows (e.g.
+   `stage`, `prod`).
+
+5. Add the `NUON_CONFIG` secret to that environment:
+
+   ```sh
+   gh secret set NUON_CONFIG --env <environment-name> < ~/.nuon
+   ```
+
+   Verify with:
+
+   ```sh
+   gh secret list --env <environment-name>
+   ```
+
+6. To make it selectable in `sync-all-apps.yaml`, add the environment name to the
+   `environment` input `options` list. To use it automatically in `sync-app.yaml`,
+   update the `environment:` expression on the `sync` job.
+
+Because the secret carries `api_url`, `org_id`, and the admin `api_token`, each
+environment is fully scoped by its own `NUON_CONFIG` — no other workflow changes
+are needed to point an environment at a different API.

--- a/.github/workflows/sync-all-apps.yaml
+++ b/.github/workflows/sync-all-apps.yaml
@@ -1,0 +1,163 @@
+name: Sync All Nuon Apps
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Environment to sync against (config comes from its NUON_CONFIG secret)"
+        required: false
+        type: choice
+        options:
+          - stage
+          - prod
+        default: prod
+      ref:
+        description: "Branch, tag, or SHA of example-app-configs to sync (default: this ref)"
+        required: false
+        type: string
+        default: ""
+      apps:
+        description: "Optional comma-separated subset of apps (default: all)"
+        required: false
+        type: string
+        default: ""
+
+  schedule:
+    - cron: "0 6 * * *"
+
+  workflow_call:
+    inputs:
+      environment:
+        type: string
+        required: false
+        default: prod
+      ref:
+        type: string
+        required: false
+        default: ""
+      apps:
+        type: string
+        required: false
+        default: ""
+    secrets:
+      NUON_CONFIG:
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sync-all-apps
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_apps: ${{ steps.set-matrix.outputs.has_apps }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Discover apps
+        id: set-matrix
+        env:
+          APPS_FILTER: ${{ inputs.apps }}
+        run: |
+          set -euo pipefail
+
+          # An "app" dir is any top-level directory containing a metadata.toml.
+          mapfile -t ALL < <(find . -mindepth 2 -maxdepth 2 -name 'metadata.toml' -printf '%h\n' \
+            | sed 's|^\./||' \
+            | sort -u)
+
+          if [ -n "${APPS_FILTER}" ]; then
+            IFS=',' read -ra REQUESTED <<< "${APPS_FILTER}"
+            SELECTED=()
+            for want in "${REQUESTED[@]}"; do
+              want_trimmed="$(echo "$want" | xargs)"
+              [ -z "$want_trimmed" ] && continue
+              found=false
+              for app in "${ALL[@]}"; do
+                if [ "$app" = "$want_trimmed" ]; then
+                  SELECTED+=("$app")
+                  found=true
+                  break
+                fi
+              done
+              if [ "$found" = false ]; then
+                echo "::warning::requested app '$want_trimmed' not found in repo; skipping"
+              fi
+            done
+          else
+            SELECTED=("${ALL[@]}")
+          fi
+
+          if [ "${#SELECTED[@]}" -eq 0 ]; then
+            echo "No apps to sync"
+            echo "has_apps=false" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"app\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          JSON_ARRAY=$(printf '%s\n' "${SELECTED[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "Apps to sync: $JSON_ARRAY"
+          echo "has_apps=true" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"app\":$JSON_ARRAY}" >> "$GITHUB_OUTPUT"
+
+  sync:
+    needs: discover
+    if: needs.discover.outputs.has_apps == 'true'
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment || 'prod' }}
+    strategy:
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+      fail-fast: false
+      max-parallel: 4
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install Nuon CLI
+        run: |
+          curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/install.sh -o "$RUNNER_TEMP/nuon-install.sh"
+          bash "$RUNNER_TEMP/nuon-install.sh" --no-input
+
+      - name: Write Nuon config
+        env:
+          NUON_CONFIG: ${{ secrets.NUON_CONFIG }}
+        run: |
+          printf '%s\n' "$NUON_CONFIG" > "$HOME/.nuon"
+          chmod 600 "$HOME/.nuon"
+
+      - name: Sync ${{ matrix.app }}
+        env:
+          APP: ${{ matrix.app }}
+        run: |
+          nuon apps sync "$APP" --create
+
+  summary:
+    needs: [discover, sync]
+    if: always() && needs.discover.outputs.has_apps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write summary
+        env:
+          MATRIX: ${{ needs.discover.outputs.matrix }}
+          SYNC_RESULT: ${{ needs.sync.result }}
+          ENVIRONMENT: ${{ inputs.environment || 'prod' }}
+          REF: ${{ inputs.ref || github.ref }}
+        run: |
+          {
+            echo "## Sync All Nuon Apps"
+            echo ""
+            echo "- **Environment:** \`$ENVIRONMENT\`"
+            echo "- **Ref:** \`$REF\`"
+            echo "- **Sync job result:** \`$SYNC_RESULT\`"
+            echo ""
+            echo "### Apps"
+            echo "$MATRIX" | jq -r '.app[] | "- `" + . + "`"'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-app.yaml
+++ b/.github/workflows/sync-app.yaml
@@ -4,32 +4,19 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
-    inputs:
-      sync_all:
-        description: Sync all apps (ignore changed-dir detection)
-        required: true
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
-      NUON_DEBUG:
-        description: NUON_DEBUG
-        required: true
-        default: "false"
-        type: choice
-        options:
-          - "true"
-          - "false"
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
 
-defaults:
-  run:
-    shell: bash
-
-env:
-  NUON_DEBUG: "${{ github.event.inputs.NUON_DEBUG }}"
-  NUON_ORG_ID: orghrsmmlfozvjxraku0ubb4qq
+permissions:
+  contents: read
 
 jobs:
   detect-changes:
@@ -40,67 +27,83 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
-      - name: Get changed directories
+      - name: Get changed app directories
         id: set-matrix
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.sha }}
         run: |
-          if [ "${{ github.event.inputs.sync_all }}" = "true" ]; then
-            # Manual dispatch: sync every app dir (exclude dotfiles, scripts, docs)
-            CHANGED_DIRS=$(find . -maxdepth 1 -mindepth 1 -type d -printf '%f\n' | sort -u | grep -v '^\.' | grep -vE '^(scripts|docs)$' || true)
-          else
-            # Get list of changed files
-            CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
+          set -euo pipefail
 
-            # Extract unique top-level directories (excluding dotfiles, scripts, docs)
-            CHANGED_DIRS=$(echo "$CHANGED_FILES" | cut -d'/' -f1 | sort -u | grep -v '^\.' | grep -v '^$' | grep -vE '^(scripts|docs)$' || true)
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
+            HEAD_SHA="$PR_HEAD_SHA"
+          else
+            BASE_SHA="$PUSH_BEFORE"
+            HEAD_SHA="$PUSH_AFTER"
           fi
 
-          if [ -z "$CHANGED_DIRS" ]; then
+          # First push to a new branch reports an all-zero base; fall back to
+          # a single-commit diff in that case.
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ]; then
+            BASE_SHA="${HEAD_SHA}~1"
+          fi
+
+          git fetch origin "$BASE_SHA" --depth=1 2>/dev/null || true
+
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          CHANGED_DIRS=$(echo "$CHANGED_FILES" | cut -d'/' -f1 | sort -u | grep -v '^$' || true)
+
+          APP_DIRS=()
+          for d in $CHANGED_DIRS; do
+            [ -f "$d/metadata.toml" ] && APP_DIRS+=("$d")
+          done
+
+          if [ "${#APP_DIRS[@]}" -eq 0 ]; then
             echo "No app directories changed"
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "matrix={\"app\":[]}" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"app\":[]}" >> "$GITHUB_OUTPUT"
           else
-            # Build JSON array for matrix
-            JSON_ARRAY=$(echo "$CHANGED_DIRS" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-            echo "Changed directories: $JSON_ARRAY"
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "matrix={\"app\":$JSON_ARRAY}" >> $GITHUB_OUTPUT
+            JSON_ARRAY=$(printf '%s\n' "${APP_DIRS[@]}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+            echo "Changed app directories: $JSON_ARRAY"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"app\":$JSON_ARRAY}" >> "$GITHUB_OUTPUT"
           fi
 
   sync:
     needs: detect-changes
-    if: needs.detect-changes.outputs.has_changes == 'true'
+    # Skip on fork PRs since secrets aren't available to the runner.
+    if: >-
+      needs.detect-changes.outputs.has_changes == 'true' &&
+      (github.event_name != 'pull_request' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
-    name: Push to Nuon
+    environment: ${{ github.event_name == 'pull_request' && 'stage' || 'prod' }}
     strategy:
       matrix: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
       fail-fast: false
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Check for skip-sync label
-        id: check_label
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Install Nuon CLI
         run: |
-          PR_NUMBER=$(gh pr list --search "${{ github.sha }}" --state merged --json number -q '.[0].number')
-          if [ -n "$PR_NUMBER" ]; then
-            LABELS=$(gh pr view "$PR_NUMBER" --json labels -q '.labels[].name')
-            if echo "$LABELS" | grep -q "skip-sync"; then
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              echo "Skipping sync due to skip-sync label on PR #$PR_NUMBER"
-            fi
-          fi
+          curl -fsSL https://nuon-artifacts.s3.us-west-2.amazonaws.com/cli/install.sh -o "$RUNNER_TEMP/nuon-install.sh"
+          bash "$RUNNER_TEMP/nuon-install.sh" --no-input
 
-      - name: Install CLI
-        if: steps.check_label.outputs.skip != 'true'
-        run: ./scripts/install-cli.sh
+      - name: Write Nuon config
+        env:
+          NUON_CONFIG: ${{ secrets.NUON_CONFIG }}
+        run: |
+          printf '%s\n' "$NUON_CONFIG" > "$HOME/.nuon"
+          chmod 600 "$HOME/.nuon"
 
       - name: Sync ${{ matrix.app }}
-        if: steps.check_label.outputs.skip != 'true'
-        working-directory: ${{ matrix.app }}
-        run: nuon apps sync .
         env:
-          NUON_API_TOKEN: ${{ secrets.NUON_API_TOKEN }}
+          APP: ${{ matrix.app }}
+        run: |
+          nuon apps sync "$APP" --create


### PR DESCRIPTION
Adds a manually/scheduled dispatchable `sync-all-apps` workflow and reworks `sync-app` to authenticate via a per-environment `NUON_CONFIG` secret with selectable environment (stage/prod), ref, and app subset.