### PR TITLE
ci: delete synced apps after sync as cleanup

### DIFF
--- a/.github/workflows/sync-all-apps.yaml
+++ b/.github/workflows/sync-all-apps.yaml
@@ -22,9 +22,6 @@ on:
         type: string
         default: ""
 
-  schedule:
-    - cron: "0 6 * * *"
-
   workflow_call:
     inputs:
       environment:
@@ -138,6 +135,15 @@ jobs:
           APP: ${{ matrix.app }}
         run: |
           nuon apps sync "$APP" --create
+
+      # sync-all-apps only validates that configs sync cleanly; always delete
+      # the app afterwards so no artifacts are left behind, in any environment.
+      - name: Cleanup ${{ matrix.app }}
+        if: ${{ always() }}
+        env:
+          APP: ${{ matrix.app }}
+        run: |
+          nuon apps delete -a "$APP" --confirm || true
 
   summary:
     needs: [discover, sync]

--- a/.github/workflows/sync-app.yaml
+++ b/.github/workflows/sync-app.yaml
@@ -107,3 +107,12 @@ jobs:
           APP: ${{ matrix.app }}
         run: |
           nuon apps sync "$APP" --create
+
+      # PR syncs only validate the config against stage; delete the app so
+      # stage doesn't accumulate throwaway apps. main pushes (prod) keep theirs.
+      - name: Cleanup ${{ matrix.app }}
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          APP: ${{ matrix.app }}
+        run: |
+          nuon apps delete -a "$APP" --confirm || true


### PR DESCRIPTION
Adds a cleanup step (`nuon apps delete --confirm`) after syncing: `sync-all-apps.yaml` always deletes (and drops the daily cron), `sync-app.yaml` deletes only on PR (stage) syncs so prod pushes keep their apps.