### PR TITLE
fix: commit missing sandbox.tfvars for 3 apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,11 @@ crash.*.log
 # Non-secret example tfvars committed so `nuon apps sync` can resolve them.
 !aca-simple/sandbox.tfvars
 !aws-lambda/sandbox.tfvars
+!byo-vpc/sandbox.tfvars
+!eks-multi-env/sandbox.tfvars
 !eks-simple-kustomize/sandbox.tfvars
 !n8n/sandbox.tfvars
+!programmable-runbook-and-readme/sandbox.tfvars
 !uptime-monitor/sandbox.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so

--- a/byo-vpc/sandbox.tfvars
+++ b/byo-vpc/sandbox.tfvars
@@ -1,0 +1,48 @@
+cluster_endpoint_public_access = true
+
+maintenance_role_eks_access_entry_policy_associations = {
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_view = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+
+additional_namespaces = ["whoami"]
+
+additional_tags = {
+  "app.nuon.co/name" : "byo-vpc"
+}
+
+eks_compute_config = {
+  enabled    = true
+  node_pools = ["general-purpose", "system"]
+}
+
+{{ if gt (len .nuon.install_stack.outputs.break_glass_role_arns) 0 }}
+break_glass_iam_role_arn = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"
+
+break_glass_role_eks_kubernetes_groups = []
+
+break_glass_role_eks_access_entry_policy_associations = {
+  cluster_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+{{ end }}

--- a/eks-multi-env/sandbox.tfvars
+++ b/eks-multi-env/sandbox.tfvars
@@ -1,0 +1,49 @@
+cluster_endpoint_public_access = true
+
+maintenance_role_eks_access_entry_policy_associations = {
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_view = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+
+additional_namespaces = ["dev", "qa", "prod"]
+
+maintenance_cluster_role_rules_override = [{
+  "apiGroups" = ["*"]
+  "resources" = ["*"]
+  "verbs"     = ["*"]
+}]
+
+min_size     = 2
+max_size     = 3
+desired_size = 2
+
+{{ if gt (len .nuon.install_stack.outputs.break_glass_role_arns) 0 }}
+break_glass_iam_role_arn = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"
+
+break_glass_role_eks_kubernetes_groups = []
+
+break_glass_role_eks_access_entry_policy_associations = {
+  cluster_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+{{ end }}

--- a/programmable-runbook-and-readme/sandbox.tfvars
+++ b/programmable-runbook-and-readme/sandbox.tfvars
@@ -1,0 +1,48 @@
+cluster_endpoint_public_access = true
+
+maintenance_role_eks_access_entry_policy_associations = {
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_view = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+
+additional_namespaces = ["whoami"]
+
+additional_tags = {
+  "app.nuon.co/name" : "programmable-runbook-and-readme"
+}
+
+eks_compute_config = {
+  enabled    = true
+  node_pools = ["general-purpose", "system"]
+}
+
+{{ if gt (len .nuon.install_stack.outputs.break_glass_role_arns) 0 }}
+break_glass_iam_role_arn = "{{ index (values .nuon.install_stack.outputs.break_glass_role_arns) 0 }}"
+
+break_glass_role_eks_kubernetes_groups = []
+
+break_glass_role_eks_access_entry_policy_associations = {
+  cluster_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+  eks_admin = {
+    policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminPolicy"
+    access_scope = {
+      type = "cluster"
+    }
+  }
+}
+{{ end }}


### PR DESCRIPTION
Adds the missing `sandbox.tfvars` files (and their `.gitignore` allowlist entries) for **byo-vpc**, **eks-multi-env**, and **programmable-runbook-and-readme**.

