### PR TITLE
fix: join subnet ids instead of hardcoding 3

### DIFF
--- a/coder/components/0-rds_subnet.toml
+++ b/coder/components/0-rds_subnet.toml
@@ -17,4 +17,4 @@ rds_subnet_name         = "rds-subnet-coder-{{ .nuon.install.id }}"
 rds_subnet_display_name = "Coder RDS Subnet {{ .nuon.install.id }}"
 # aws details
 region             = "{{ .nuon.sandbox.outputs.account.region }}"
-private_subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+private_subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'

--- a/coder/components/1-rds_cluster_coder.toml
+++ b/coder/components/1-rds_cluster_coder.toml
@@ -21,7 +21,7 @@ subnet_group_id = "{{ .nuon.components.rds_subnet.outputs.id }}"
 
 region     = "{{ .nuon.install_stack.outputs.region }}"
 vpc_id     = "{{ .nuon.install_stack.outputs.vpc_id }}"
-subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 
 nuon_id = "{{ .nuon.install.id }}"
 

--- a/data-ops/components/1-rds_cluster_temporal.toml
+++ b/data-ops/components/1-rds_cluster_temporal.toml
@@ -23,6 +23,6 @@ apply_immediately = "true"
 
 region     = "{{ .nuon.install_stack.outputs.region }}"
 vpc_id     = "{{ .nuon.install_stack.outputs.vpc_id }}"
-subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 
 nuon_id = "{{ .nuon.install.id }}"

--- a/data-ops/components/1-rds_subnet.toml
+++ b/data-ops/components/1-rds_subnet.toml
@@ -16,4 +16,4 @@ rds_subnet_name         = "rds-subnet-0-{{ .nuon.install.id }}"
 rds_subnet_display_name = "RDS Subnet {{ .nuon.install.id }}"
 # aws details
 region             = "{{ .nuon.sandbox.outputs.account.region }}"
-private_subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+private_subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'

--- a/forgejo-aws/components/2-pulumi-rds.toml
+++ b/forgejo-aws/components/2-pulumi-rds.toml
@@ -14,7 +14,7 @@ branch    = "main"
 [env_vars]
 INSTALL_ID         = "{{ .nuon.install.id }}"
 VPC_ID             = "{{ .nuon.install.sandbox.outputs.vpc.id }}"
-PRIVATE_SUBNET_IDS = "{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 0 }},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+PRIVATE_SUBNET_IDS = '{{ .nuon.install.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 NODE_SECURITY_GROUP_ID = "{{ .nuon.install.sandbox.outputs.cluster.node_security_group_id }}"
 DB_INSTANCE_CLASS  = "{{ .nuon.inputs.inputs.db_instance_class }}"
 DB_STORAGE_GB      = "{{ .nuon.inputs.inputs.db_storage_gb }}"

--- a/forgejo-aws/components/3-pulumi-redis.toml
+++ b/forgejo-aws/components/3-pulumi-redis.toml
@@ -14,6 +14,6 @@ branch    = "main"
 [env_vars]
 INSTALL_ID             = "{{ .nuon.install.id }}"
 VPC_ID                 = "{{ .nuon.install.sandbox.outputs.vpc.id }}"
-PRIVATE_SUBNET_IDS     = "{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 0 }},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+PRIVATE_SUBNET_IDS     = '{{ .nuon.install.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 NODE_SECURITY_GROUP_ID = "{{ .nuon.install.sandbox.outputs.cluster.node_security_group_id }}"
 REDIS_NODE_TYPE        = "{{ .nuon.inputs.inputs.redis_node_type }}"

--- a/grafana/components/0-rds_subnet.toml
+++ b/grafana/components/0-rds_subnet.toml
@@ -16,4 +16,4 @@ rds_subnet_name         = "rds-subnet-grafana-{{ .nuon.install.id }}"
 rds_subnet_display_name = "Grafana RDS Subnet {{ .nuon.install.id }}"
 # aws details
 region             = "{{ .nuon.sandbox.outputs.account.region }}"
-private_subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+private_subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'

--- a/grafana/components/1-rds_cluster_exampledb.toml
+++ b/grafana/components/1-rds_cluster_exampledb.toml
@@ -22,7 +22,7 @@ subnet_group_id = "{{ .nuon.components.rds_subnet.outputs.id }}"
 
 region     = "{{ .nuon.install_stack.outputs.region }}"
 vpc_id     = "{{ .nuon.install_stack.outputs.vpc_id }}"
-subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 
 nuon_id = "{{ .nuon.install.id }}"
 

--- a/grafana/components/1-rds_cluster_grafana.toml
+++ b/grafana/components/1-rds_cluster_grafana.toml
@@ -21,7 +21,7 @@ subnet_group_id = "{{ .nuon.components.rds_subnet.outputs.id }}"
 
 region     = "{{ .nuon.install_stack.outputs.region }}"
 vpc_id     = "{{ .nuon.install_stack.outputs.vpc_id }}"
-subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 
 nuon_id = "{{ .nuon.install.id }}"
 

--- a/langfuse/components/0-rds_subnet.toml
+++ b/langfuse/components/0-rds_subnet.toml
@@ -14,4 +14,4 @@ install_id              = "{{ .nuon.install.id }}"
 rds_subnet_name         = "rds-subnet-langfuse-{{ .nuon.install.id }}"
 rds_subnet_display_name = "Langfuse RDS Subnet {{ .nuon.install.id }}"
 region                  = "{{ .nuon.sandbox.outputs.account.region }}"
-private_subnet_ids      = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+private_subnet_ids      = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'

--- a/langfuse/components/1-rds_postgres.toml
+++ b/langfuse/components/1-rds_postgres.toml
@@ -20,7 +20,7 @@ subnet_group_id = "{{ .nuon.components.rds_subnet.outputs.id }}"
 
 region     = "{{ .nuon.install_stack.outputs.region }}"
 vpc_id     = "{{ .nuon.install_stack.outputs.vpc_id }}"
-subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 
 nuon_id = "{{ .nuon.install.id }}"
 

--- a/langfuse/components/5-elasticache_redis.toml
+++ b/langfuse/components/5-elasticache_redis.toml
@@ -13,4 +13,4 @@ branch    = "main"
 install_id = "{{ .nuon.install.id }}"
 region     = "{{ .nuon.install_stack.outputs.region }}"
 vpc_id     = "{{ .nuon.install_stack.outputs.vpc_id }}"
-subnet_ids = "{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 0 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+subnet_ids = '{{ .nuon.sandbox.outputs.vpc.private_subnet_ids | join "," }}'

--- a/uptime-monitor/components/1-rds.toml
+++ b/uptime-monitor/components/1-rds.toml
@@ -83,5 +83,5 @@ branch    = "main"
 region                 = "{{ .nuon.install_stack.outputs.region }}"
 install_id             = "{{ .nuon.install.id }}"
 vpc_id                 = "{{ .nuon.install.sandbox.outputs.vpc.id }}"
-private_subnet_ids     = "{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 0}},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 1 }},{{ index .nuon.install.sandbox.outputs.vpc.private_subnet_ids 2 }}"
+private_subnet_ids     = '{{ .nuon.install.sandbox.outputs.vpc.private_subnet_ids | join "," }}'
 node_security_group_id = "{{ .nuon.install.sandbox.outputs.cluster.node_security_group_id }}"


### PR DESCRIPTION
components concatenated private_subnet_ids[0..2], breaking with 'slice index out of range' on sandboxes returning 2 subnets (coder's auto-sandbox). join the whole list, works for any AZ count. fixes coder + data-ops, forgejo-aws, grafana, langfuse, uptime-monitor.