### PR TITLE
feat: gcp-gcs-bucket custom stacks example

### DIFF
--- a/gcp-gcs-bucket/README.md
+++ b/gcp-gcs-bucket/README.md
@@ -1,0 +1,35 @@
+# GCP GCS Bucket (custom stacks)
+
+The GCP parallel of the AWS persistence pattern: a **curated custom stack**
+creates a GCS bucket during the customer's install-stack apply — as the
+customer's admin credentials, before any component runs — and a pass-through
+component reads it back and emits outputs for downstream use.
+
+## How it works
+
+1. `stack.toml` declares a `[[custom_nested_stacks]]` entry pointing at the
+   curated `bucket` module in the install-stacks repo:
+
+   ```toml
+   [[custom_nested_stacks]]
+   name         = "storage"
+   template_url = "github.com/nuonco/install-stacks//gcp/modules/bucket"
+   index        = 0
+   ```
+
+   The install stack creates the bucket as `<install-id>-storage`. Parameters
+   map to install inputs (here: `versioning`).
+
+2. Outputs phone home under
+   `{{.nuon.install_stack.outputs.custom_nested_stacks.storage.outputs.*}}`.
+
+3. `components/0-bucket.toml` is a pass-through terraform component that reads
+   the bucket by its conventional name and re-emits `name`, `url`, and
+   `self_link` as component outputs — reference them from any other component
+   as `{{.nuon.components.bucket.outputs.name}}`.
+
+## Requirements
+
+Curated GCP custom stacks need nuon#1943 + nuon#1944 (renderer) and
+install-stacks#24 (the `bucket` module). Until those land, this config
+validates but the bucket is not created.

--- a/gcp-gcs-bucket/components/0-bucket.toml
+++ b/gcp-gcs-bucket/components/0-bucket.toml
@@ -7,7 +7,7 @@ terraform_version = "1.11.3"
 [public_repo]
 repo      = "nuonco/example-app-configs"
 directory = "gcp-gcs-bucket/src/components/bucket"
-branch    = "main"
+branch    = "am/gcp-gcs-bucket"
 
 [vars]
 install_id = "{{.nuon.install.id}}"

--- a/gcp-gcs-bucket/components/0-bucket.toml
+++ b/gcp-gcs-bucket/components/0-bucket.toml
@@ -1,0 +1,14 @@
+# Pass-through: reads the bucket the install stack created and emits outputs
+# for downstream components.
+name              = "bucket"
+type              = "terraform_module"
+terraform_version = "1.11.3"
+
+[public_repo]
+repo      = "nuonco/example-app-configs"
+directory = "gcp-gcs-bucket/src/components/bucket"
+branch    = "main"
+
+[vars]
+install_id = "{{.nuon.install.id}}"
+project_id = "{{.nuon.install_stack.outputs.project_id}}"

--- a/gcp-gcs-bucket/inputs.toml
+++ b/gcp-gcs-bucket/inputs.toml
@@ -1,0 +1,12 @@
+[[group]]
+name         = "storage"
+description  = "Storage configuration"
+display_name = "Storage"
+
+[[input]]
+name         = "bucket_versioning"
+description  = "Enable object versioning on the customer-created bucket."
+default      = "false"
+display_name = "Bucket Versioning"
+group        = "storage"
+type         = "bool"

--- a/gcp-gcs-bucket/metadata.toml
+++ b/gcp-gcs-bucket/metadata.toml
@@ -1,0 +1,11 @@
+version = "v2"
+
+display_name = "GCP GCS Bucket (custom stacks)"
+description  = "Customer-created GCS bucket via a curated install-stack custom stack, read back by a pass-through component."
+readme       = "./README.md"
+
+[onboarding]
+enabled        = true
+category       = "architecture"
+difficulty     = "simple"
+cloud_provider = "gcp"

--- a/gcp-gcs-bucket/permissions/deprovision.toml
+++ b/gcp-gcs-bucket/permissions/deprovision.toml
@@ -1,0 +1,9 @@
+type           = "deprovision"
+name           = "{{.nuon.install.id}}-deprovision"
+description    = "deprovision sandbox and components."
+display_name   = "deprovision role"
+cloud_platform = "gcp"
+
+[[policies]]
+name                = "owner"
+gcp_predefined_role = "roles/owner"

--- a/gcp-gcs-bucket/permissions/maintenance.toml
+++ b/gcp-gcs-bucket/permissions/maintenance.toml
@@ -1,0 +1,9 @@
+type           = "maintenance"
+name           = "{{.nuon.install.id}}-maintenance"
+description    = "operate and remediate the app's components and use actions."
+display_name   = "maintenance role"
+cloud_platform = "gcp"
+
+[[policies]]
+name                = "owner"
+gcp_predefined_role = "roles/owner"

--- a/gcp-gcs-bucket/permissions/provision.toml
+++ b/gcp-gcs-bucket/permissions/provision.toml
@@ -1,0 +1,9 @@
+type           = "provision"
+name           = "{{.nuon.install.id}}-provision"
+description    = "provision the sandbox and components; trigger actions."
+display_name   = "provision role"
+cloud_platform = "gcp"
+
+[[policies]]
+name                = "owner"
+gcp_predefined_role = "roles/owner"

--- a/gcp-gcs-bucket/runner.toml
+++ b/gcp-gcs-bucket/runner.toml
@@ -1,0 +1,4 @@
+# runner
+runner_type = "gcp"
+helm_driver = "configmap"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/tags/gcp-v0.1.4/scripts/gcp/init.sh"

--- a/gcp-gcs-bucket/sandbox.toml
+++ b/gcp-gcs-bucket/sandbox.toml
@@ -1,0 +1,11 @@
+terraform_version = "1.11.3"
+
+[public_repo]
+directory = "."
+repo      = "nuonco/gcp-min-sandbox"
+branch    = "main"
+
+[vars]
+enable_nuon_dns      = "false"
+public_root_domain   = "{{ .nuon.install.id }}.nuon.run"
+internal_root_domain = "internal.{{ .nuon.install.id }}.nuon.run"

--- a/gcp-gcs-bucket/src/components/bucket/main.tf
+++ b/gcp-gcs-bucket/src/components/bucket/main.tf
@@ -2,3 +2,10 @@
 data "google_storage_bucket" "main" {
   name = "${var.install_id}-storage"
 }
+
+# Proof of life: written on every deploy so the bucket is verifiably usable.
+resource "google_storage_bucket_object" "marker" {
+  bucket  = data.google_storage_bucket.main.name
+  name    = "nuon/installed-by.txt"
+  content = "install ${var.install_id}"
+}

--- a/gcp-gcs-bucket/src/components/bucket/main.tf
+++ b/gcp-gcs-bucket/src/components/bucket/main.tf
@@ -1,0 +1,4 @@
+# The install stack's custom stack creates the bucket as <install-id>-<stack key>.
+data "google_storage_bucket" "main" {
+  name = "${var.install_id}-storage"
+}

--- a/gcp-gcs-bucket/src/components/bucket/outputs.tf
+++ b/gcp-gcs-bucket/src/components/bucket/outputs.tf
@@ -9,3 +9,7 @@ output "url" {
 output "self_link" {
   value = data.google_storage_bucket.main.self_link
 }
+
+output "marker_object" {
+  value = "gs://${data.google_storage_bucket.main.name}/${google_storage_bucket_object.marker.name}"
+}

--- a/gcp-gcs-bucket/src/components/bucket/outputs.tf
+++ b/gcp-gcs-bucket/src/components/bucket/outputs.tf
@@ -1,0 +1,11 @@
+output "name" {
+  value = data.google_storage_bucket.main.name
+}
+
+output "url" {
+  value = data.google_storage_bucket.main.url
+}
+
+output "self_link" {
+  value = data.google_storage_bucket.main.self_link
+}

--- a/gcp-gcs-bucket/src/components/bucket/providers.tf
+++ b/gcp-gcs-bucket/src/components/bucket/providers.tf
@@ -1,0 +1,3 @@
+provider "google" {
+  project = var.project_id
+}

--- a/gcp-gcs-bucket/src/components/bucket/variables.tf
+++ b/gcp-gcs-bucket/src/components/bucket/variables.tf
@@ -1,0 +1,7 @@
+variable "install_id" {
+  type = string
+}
+
+variable "project_id" {
+  type = string
+}

--- a/gcp-gcs-bucket/src/components/bucket/versions.tf
+++ b/gcp-gcs-bucket/src/components/bucket/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/gcp-gcs-bucket/stack.toml
+++ b/gcp-gcs-bucket/stack.toml
@@ -1,0 +1,14 @@
+type        = "gcp-terraform"
+name        = "nuon-gcs-bucket-{{.nuon.install.id}}"
+description = "Install the Nuon runner and a customer-created GCS bucket."
+
+# Curated custom stack: the customer's install stack apply creates the bucket
+# (named <install-id>-storage) as admin, before any component runs. Outputs
+# surface under {{.nuon.install_stack.outputs.custom_nested_stacks.storage.*}}.
+[[custom_nested_stacks]]
+name         = "storage"
+template_url = "github.com/nuonco/install-stacks//gcp/modules/bucket"
+index        = 0
+
+[custom_nested_stacks.parameters]
+versioning = "{{.nuon.install.inputs.bucket_versioning}}"


### PR DESCRIPTION
GCP parallel of the aws persistence pattern: a curated custom stack creates a GCS bucket (`<install-id>-storage`) during the customer's install-stack apply, and a pass-through component reads it back and emits outputs for downstream components. Demonstrates custom-stack parameters wired to an install input (`bucket_versioning`).

Depends on nuon#1943 + nuon#1944 (gcp renderer) and install-stacks#24 (curated bucket module) — noted in the README; the config validates today and activates once those merge.
