### PR TITLE
feat: azure per-operation identities for aks-simple

### DIFF
--- a/aks-simple/break_glass.toml
+++ b/aks-simple/break_glass.toml
@@ -1,14 +1,11 @@
 [[role]]
 name                 = "{{.nuon.install.id}}-aks-simple-sandbox-break-glass"
+cloud_platform       = "azure"
 description          = "grants access to the sandbox for install {{.nuon.install.id}}."
 display_name         = "break glass role"
 
-# Placeholder policy for Azure (actual permissions via RBAC)
+# Bound to a dedicated break-glass managed identity, assumed only when explicitly
+# selected. Owner grants full access to the install's resource group.
 [[role.policies]]
-name = "placeholder"
-contents = """
-{
-    "Version": "2012-10-17",
-    "Statement": []
-}
-"""
+name = "break-glass"
+azure_built_in_roles = ["Owner"]

--- a/aks-simple/permissions/deprovision.toml
+++ b/aks-simple/permissions/deprovision.toml
@@ -1,6 +1,9 @@
 type = "deprovision"
+cloud_platform = "azure"
 name = "{{.nuon.install.id}}-deprovision"
 description = "deprovision sandbox and components."
 display_name = "deprovision role"
 
 [[policies]]
+name = "deprovision"
+azure_built_in_roles = ["Contributor"]

--- a/aks-simple/permissions/dns-manager.toml
+++ b/aks-simple/permissions/dns-manager.toml
@@ -1,0 +1,17 @@
+type = "custom"
+cloud_platform = "azure"
+name = "{{.nuon.install.id}}-dns-manager"
+description = "manage DNS zones and records for the install."
+display_name = "dns manager role"
+
+# A fine-grained custom role: azure_actions are rolled into an Azure custom role
+# definition bound to a dedicated managed identity (vs azure_built_in_roles, which
+# assign Azure-managed roles).
+[[policies]]
+name = "dns"
+azure_actions = [
+  "Microsoft.Network/dnsZones/read",
+  "Microsoft.Network/dnsZones/recordSets/read",
+  "Microsoft.Network/dnsZones/recordSets/write",
+  "Microsoft.Network/dnsZones/recordSets/delete",
+]

--- a/aks-simple/permissions/dns-manager.toml
+++ b/aks-simple/permissions/dns-manager.toml
@@ -11,7 +11,7 @@ display_name = "dns manager role"
 name = "dns"
 azure_actions = [
   "Microsoft.Network/dnsZones/read",
-  "Microsoft.Network/dnsZones/recordSets/read",
-  "Microsoft.Network/dnsZones/recordSets/write",
-  "Microsoft.Network/dnsZones/recordSets/delete",
+  "Microsoft.Network/dnsZones/write",
+  "Microsoft.Network/dnsZones/delete",
+  "Microsoft.Network/dnsZones/*",
 ]

--- a/aks-simple/permissions/maintenance.toml
+++ b/aks-simple/permissions/maintenance.toml
@@ -1,6 +1,12 @@
 type = "maintenance"
+cloud_platform = "azure"
 name = "{{ .nuon.install.id }}-maintenance"
 description = "operate and remediate the app's components and use actions."
 display_name = "maintenance role"
 
 [[policies]]
+name = "maintenance"
+azure_built_in_roles = [
+  "Contributor",
+  "Azure Kubernetes Service RBAC Cluster Admin",
+]

--- a/aks-simple/permissions/provision.toml
+++ b/aks-simple/permissions/provision.toml
@@ -1,6 +1,15 @@
 type = "provision"
+cloud_platform = "azure"
 name = "{{.nuon.install.id}}-provision"
 description = "provision the sandbox and components; trigger actions."
 display_name = "provision role"
 
+# Bound to a per-operation user-assigned managed identity that the runner assumes
+# for provision work. The runner's own identity holds no deploy permissions.
 [[policies]]
+name = "provision"
+azure_built_in_roles = [
+  "Contributor",
+  "Role Based Access Control Administrator",
+  "Azure Kubernetes Service RBAC Cluster Admin",
+]


### PR DESCRIPTION
Declares Azure operation roles (provision/maintenance/deprovision + break-glass) with `cloud_platform = "azure"` and `azure_built_in_roles`, so the runner assumes a scoped per-operation managed identity instead of relying on broad grants on its own identity. Pairs with nuon PR #1946.