### PR TITLE
App Branches launch: eks-simple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ installs.
 
 Creates an EKS cluster with a `whoami` application deployed on it, an Application Load Balancer and a Certificate. See
 the Nuon docs for [a step-by-step guide](https://docs.nuon.co/get-started/create-your-first-app) on how to deploy this
-app.
+app. Also the reference example for **app branches**: `branch.toml` connects the `main` branch of this repo to the app so
+a `git push` rolls the change out to installs, one deployment group at a time — first the installs labelled
+`env=stage`, then those labelled `env=prod`, with a plan and an approval gate before each group deploys.
 
 ## cde
 

--- a/eks-simple/.meta.yaml
+++ b/eks-simple/.meta.yaml
@@ -9,6 +9,7 @@ features:
   - actions
   - policies
   - secrets
+  - branches
 tags:
   - eks
   - kubernetes

--- a/eks-simple/README.md
+++ b/eks-simple/README.md
@@ -74,6 +74,14 @@ X-Forwarded-Proto: https
 
 ```
 
+## Continuous delivery via app branches
+
+This app is connected to the `main` branch of
+[nuonco/example-app-configs](https://github.com/nuonco/example-app-configs) through its `branch.toml`, so a push to that
+branch starts a coordinated update instead of a per-install change. Installs roll out by deployment group in order —
+installs labelled `env=stage` first, then `env=prod` — and every group is planned and waits for an approval before
+anything is deployed, so you always see the diff first.
+
 ## Cost Estimate
 Running this app in your environment will cost around $8/day.
 

--- a/eks-simple/branch.toml
+++ b/eks-simple/branch.toml
@@ -1,0 +1,20 @@
+name = "main"
+
+[public_repo]
+directory = "eks-simple"
+repo      = "nuonco/example-app-configs"
+branch    = "main"
+
+[[install_groups]]
+name  = "stage"
+order = 1
+
+[install_groups.label_selector]
+env = "stage"
+
+[[install_groups]]
+name  = "production"
+order = 2
+
+[install_groups.label_selector]
+env = "prod"

--- a/eks-simple/installs/eks-simple-ci-stage.toml
+++ b/eks-simple/installs/eks-simple-ci-stage.toml
@@ -3,6 +3,9 @@
 name = "eks-simple-ci-stage"
 approval_option = "approve-all"
 
+[labels]
+env = "stage"
+
 [aws_account]
   region = "us-east-1"
 


### PR DESCRIPTION
## What

Makes `eks-simple` the first example app with an App Branches config, for the launch:

- `eks-simple/branch.toml` — single `main` branch via `[public_repo]`, two ordered deployment groups selected by label (`env=stage` → `env=prod`). Label selectors were chosen over `install_names` deliberately: names resolve at sync time and hard-fail on a fresh app, which is exactly what `sync-all-apps.yaml` / `install-test.yaml` create.
- `eks-simple/installs/eks-simple-ci-stage.toml` — gains `[labels] env = "stage"` so the pre-declared install lands in the `stage` group.
- `eks-simple/.meta.yaml` — `branches` added to `features:` (feeds the catalog).
- Root `README.md` + `eks-simple/README.md` — short app-branches sections.

`installs_directory` (GitOps'd install configs) was deliberately **not** used: eks-simple is a repo-subdirectory app, and the #1930 path resolution is unreliable for that shape (details in the launch notes).

## Verification

- Offline: parsed with the real `parse.ParseDir` from the #1930 branch + explicit `AppBranchConfig.Validate()` — clean, both groups resolve, install config parses with the label.
- **NOT live-synced**: no valid stage credentials were available. Before merge, run `sync-all-apps.yaml` with `apps: eks-simple` against stage AND confirm the `app-branches` org feature flag is enabled for the CI orgs (a missing key reads as disabled and fails the whole sync once branch.toml exists).
- Independent claims review passed.

## Merge sequencing

Merge FIRST of the three launch PRs, and only after nuonco/nuon#1930 is merged. Full sequence in the launch checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)