### PR TITLE
feat: App Branches Launch Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ installs.
 
 Creates an EKS cluster with a `whoami` application deployed on it, an Application Load Balancer and a Certificate. See
 the Nuon docs for [a step-by-step guide](https://docs.nuon.co/get-started/create-your-first-app) on how to deploy this
-app.
+app. Also the reference example for **app branches**: `branch.toml` connects the `main` branch of this repo to the app so
+a `git push` rolls the change out to installs, one deployment group at a time — first the installs labelled
+`env=stage`, then those labelled `env=prod`, with a plan and an approval gate before each group deploys.
 
 ## cde
 

--- a/eks-simple/.meta.yaml
+++ b/eks-simple/.meta.yaml
@@ -9,6 +9,7 @@ features:
   - actions
   - policies
   - secrets
+  - branches
 tags:
   - eks
   - kubernetes

--- a/eks-simple/README.md
+++ b/eks-simple/README.md
@@ -82,6 +82,11 @@ branch starts a coordinated update instead of a per-install change. Installs rol
 installs labelled `env=stage` first, then `env=prod` — and every group is planned and waits for an approval before
 anything is deployed, so you always see the diff first.
 
+To demo the flow you need installs for the groups to deploy to: after `nuon apps sync`, create them from the config
+files in [`installs/`](./installs) by running `nuon installs sync -d installs/` — see the
+[CLI reference](https://docs.nuon.co/cli-commands) and the
+[app branches guide](https://docs.nuon.co/guides/app-branches).
+
 ## Cost Estimate
 Running this app in your environment will cost around $8/day.
 

--- a/eks-simple/README.md
+++ b/eks-simple/README.md
@@ -74,6 +74,14 @@ X-Forwarded-Proto: https
 
 ```
 
+## Continuous delivery via app branches
+
+This app is connected to the `main` branch of
+[nuonco/example-app-configs](https://github.com/nuonco/example-app-configs) through its `branch.toml`, so a push to that
+branch starts a coordinated update instead of a per-install change. Installs roll out by deployment group in order —
+installs labelled `env=stage` first, then `env=prod` — and every group is planned and waits for an approval before
+anything is deployed, so you always see the diff first.
+
 ## Cost Estimate
 Running this app in your environment will cost around $8/day.
 

--- a/eks-simple/README.md
+++ b/eks-simple/README.md
@@ -87,6 +87,11 @@ files in [`installs/`](./installs) by running `nuon installs sync -d installs/` 
 [CLI reference](https://docs.nuon.co/cli-commands) and the
 [app branches guide](https://docs.nuon.co/guides/app-branches).
 
+The two installs approve differently on purpose: the stage install has `approval_option = "approve-all"`, so the
+first group deploys on its own, while the prod install has `approval_option = "prompt"`. A branch run will finish
+stage and then **wait at the production group until someone approves its plan** — if a run looks stalled after stage
+succeeds, it is waiting on you. Approve it from the run's deployment plan in the dashboard, or skip the group.
+
 ## Cost Estimate
 Running this app in your environment will cost around $8/day.
 

--- a/eks-simple/branch.toml
+++ b/eks-simple/branch.toml
@@ -1,3 +1,6 @@
+# Connects this app to a git branch: a push to `main` rolls changes out across
+# installs, one deployment group at a time. Docs: https://docs.nuon.co/config-ref/branch
+
 name = "main"
 
 [public_repo]

--- a/eks-simple/branch.toml
+++ b/eks-simple/branch.toml
@@ -1,0 +1,20 @@
+name = "main"
+
+[public_repo]
+directory = "eks-simple"
+repo      = "nuonco/example-app-configs"
+branch    = "main"
+
+[[install_groups]]
+name  = "stage"
+order = 1
+
+[install_groups.label_selector]
+env = "stage"
+
+[[install_groups]]
+name  = "production"
+order = 2
+
+[install_groups.label_selector]
+env = "prod"

--- a/eks-simple/installs/eks-simple-ci-prod.toml
+++ b/eks-simple/installs/eks-simple-ci-prod.toml
@@ -1,0 +1,14 @@
+#:schema https://api.nuon.co/v1/general/config-schema?type=install
+
+name = "eks-simple-ci-prod"
+approval_option = "approve-all"
+
+[labels]
+env = "prod"
+
+[aws_account]
+  region = "us-east-1"
+
+[[inputs]]
+domain = "nuon.run"
+sub_domain = "whoami"

--- a/eks-simple/installs/eks-simple-ci-prod.toml
+++ b/eks-simple/installs/eks-simple-ci-prod.toml
@@ -1,7 +1,7 @@
 #:schema https://api.nuon.co/v1/general/config-schema?type=install
 
 name = "eks-simple-ci-prod"
-approval_option = "approve-all"
+approval_option = "prompt"
 
 [labels]
 env = "prod"

--- a/eks-simple/installs/eks-simple-ci-prod.toml
+++ b/eks-simple/installs/eks-simple-ci-prod.toml
@@ -1,5 +1,8 @@
 #:schema https://api.nuon.co/v1/general/config-schema?type=install
 
+# Prod install: `env=prod` places it in the branch's second deployment group,
+# and every deploy waits for approval. Docs: https://docs.nuon.co/config-ref/install
+
 name = "eks-simple-ci-prod"
 approval_option = "prompt"
 

--- a/eks-simple/installs/eks-simple-ci-prod.toml
+++ b/eks-simple/installs/eks-simple-ci-prod.toml
@@ -1,17 +1,21 @@
 #:schema https://api.nuon.co/v1/general/config-schema?type=install
 
-# Prod install: `env=prod` places it in the branch's second deployment group,
-# and every deploy waits for approval. Docs: https://docs.nuon.co/config-ref/install
+# install
+# Prod install for the app branches demo: `env=prod` places it in the branch's
+# second deployment group. Docs: https://docs.nuon.co/config-ref/install
 
 name = "eks-simple-ci-prod"
-approval_option = "prompt"
 
 [labels]
 env = "prod"
 
-[aws_account]
-  region = "us-east-1"
+# Valid options: 'prompt' (default, requires manual approval) or 'approve-all' (automatic approval)
+approval_option = "prompt"
 
+[aws_account]
+region = "us-east-1"
+
+# input.group: dns
 [[inputs]]
 domain = "nuon.run"
 sub_domain = "whoami"

--- a/eks-simple/installs/eks-simple-ci-stage.toml
+++ b/eks-simple/installs/eks-simple-ci-stage.toml
@@ -1,17 +1,21 @@
 #:schema https://api.nuon.co/v1/general/config-schema?type=install
 
-# Stage install: `env=stage` places it in the branch's first deployment group,
-# and deploys are approved automatically. Docs: https://docs.nuon.co/config-ref/install
+# install
+# Stage install for the app branches demo: `env=stage` places it in the branch's
+# first deployment group. Docs: https://docs.nuon.co/config-ref/install
 
 name = "eks-simple-ci-stage"
-approval_option = "approve-all"
 
 [labels]
 env = "stage"
 
-[aws_account]
-  region = "us-east-1"
+# Valid options: 'prompt' (default, requires manual approval) or 'approve-all' (automatic approval)
+approval_option = "approve-all"
 
+[aws_account]
+region = "us-east-1"
+
+# input.group: dns
 [[inputs]]
 domain = "nuon.run"
 sub_domain = "whoami"

--- a/eks-simple/installs/eks-simple-ci-stage.toml
+++ b/eks-simple/installs/eks-simple-ci-stage.toml
@@ -10,5 +10,5 @@ env = "stage"
   region = "us-east-1"
 
 [[inputs]]
-domain = "stage.nuon.run"
+domain = "nuon.run"
 sub_domain = "whoami"

--- a/eks-simple/installs/eks-simple-ci-stage.toml
+++ b/eks-simple/installs/eks-simple-ci-stage.toml
@@ -3,6 +3,9 @@
 name = "eks-simple-ci-stage"
 approval_option = "approve-all"
 
+[labels]
+env = "stage"
+
 [aws_account]
   region = "us-east-1"
 

--- a/eks-simple/installs/eks-simple-ci-stage.toml
+++ b/eks-simple/installs/eks-simple-ci-stage.toml
@@ -1,5 +1,8 @@
 #:schema https://api.nuon.co/v1/general/config-schema?type=install
 
+# Stage install: `env=stage` places it in the branch's first deployment group,
+# and deploys are approved automatically. Docs: https://docs.nuon.co/config-ref/install
+
 name = "eks-simple-ci-stage"
 approval_option = "approve-all"
 


### PR DESCRIPTION
## What

Makes `eks-simple` the first example app with an App Branches config, for the launch:

- `eks-simple/branch.toml` — single `main` branch via `[public_repo]`, two ordered deployment groups selected by label (`env=stage` → `env=prod`). Label selectors were chosen over `install_names` deliberately: names resolve at sync time and hard-fail on a fresh app, which is exactly what `sync-all-apps.yaml` / `install-test.yaml` create.
- `eks-simple/installs/eks-simple-ci-stage.toml` — gains `[labels] env = "stage"` so the pre-declared install lands in the `stage` group.
- `eks-simple/.meta.yaml` — `branches` added to `features:` (feeds the catalog).
- Root `README.md` + `eks-simple/README.md` — short app-branches sections.

`installs_directory` (GitOps'd install configs) was deliberately **not** used: eks-simple is a repo-subdirectory app, and the #1930 path resolution is unreliable for that shape (details in the launch notes).
