### PR TITLE
chore: Fix aks-simple ingress class

### DIFF
--- a/aks-simple/src/components/ingress/templates/ingress.tpl
+++ b/aks-simple/src/components/ingress/templates/ingress.tpl
@@ -6,9 +6,8 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     app.nuon.co/install: {{ .Values.install_name }}
-  annotations:
-    kubernetes.io/ingress.class: azure/application-gateway
 spec:
+  ingressClassName: nginx
   rules:
     - host: {{ .Values.domain }}
       http:


### PR DESCRIPTION
The ingress template annotated `kubernetes.io/ingress.class: azure/application-gateway`, but aks-simple deploys nginx (`nginx_ingress_controller.toml`). nginx refuses the ingress — `ignoring ingress ... ingress class annotation is not equal to the expected by Ingress Controller` — so `status.loadBalancer` is never populated and the host never resolves. Seen on a live install where it sat that way for 15 hours.

Replaced with `spec.ingressClassName: nginx`, which is what nginx's `--ingress-class=nginx` matches and the supported field since 1.22. `application-gateway` appeared nowhere else in the config, so it was a leftover rather than an AGIC setup.