### PR TITLE
feat: remove full state from readmes

### DIFF
--- a/aca-simple/README.md
+++ b/aca-simple/README.md
@@ -72,6 +72,4 @@ Check registration status with:
 az provider show --namespace Microsoft.App --query "registrationState"
 ```
 
-## Full State
 
-Click "Manage > State"

--- a/aks-simple/README.md
+++ b/aks-simple/README.md
@@ -33,9 +33,4 @@ X-Forwarded-Port: 443
 X-Forwarded-Proto: https
 ```
 
-### Full State
 
-<details>
-<summary>Full Install State</summary>
-<pre>{{ toPrettyJson .nuon }}</pre>
-</details>

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -133,6 +133,4 @@ See also the "Components" Tab.
 <pre>{{ toPrettyJson .nuon.inputs }}</pre>
 </details>
 
-### Full State
 
-In the top right of this page, click "Manage" > "View State".

--- a/ecs-breakglass/README.md
+++ b/ecs-breakglass/README.md
@@ -274,9 +274,7 @@ aws logs tail {{ .nuon.components.whoami.outputs.cloudwatch_log_group_name }} \
 
 {{ end }}
 
-## Full State
 
-Click "Manage > State"
 
 ## Cost Estimate
 Running this app in your environment will cost around $3/day.

--- a/ecs-simple/README.md
+++ b/ecs-simple/README.md
@@ -67,9 +67,7 @@ A simple ECS cluster with capacity for EC2 based services and Fargate services.
 
 The whoami service.
 
-## Full State
 
-Click "Manage > State"
 
 ## Cost Estimate
 Running this app in your environment will cost around $2/day.

--- a/eks-karpenter-image-cache/README.md
+++ b/eks-karpenter-image-cache/README.md
@@ -63,9 +63,4 @@ AWS Region: {{ .nuon.install_stack.outputs.region }}
 
 ```
 
-### Full State
 
-<details>
-<summary>Full Install State</summary>
-<pre>{{ toPrettyJson .nuon }}</pre>
-</details>


### PR DESCRIPTION
Removes full state rendering and outdated UI navigation instructions from example app READMEs.

## Background

We now have a dedicated button in the UI for displaying full install state, making both the embedded state rendering and the old "Manage > State" navigation instructions obsolete.

Additionally, apps that were rendering the full state via `{{ toPrettyJson .nuon }}` were causing page load performance issues.

## Changes

**Removed full state rendering from:**
- aks-simple
- eks-karpenter-image-cache

**Removed outdated "Manage > State" UI directions from:**
- aca-simple
- clickhouse
- ecs-breakglass
- ecs-simple
