### PR TITLE
feat: enhance httpbin readme

### DIFF
--- a/httpbin/README.md
+++ b/httpbin/README.md
@@ -11,11 +11,9 @@ A simple service used to test and debug HTTP requests. Built with the [go-httpbi
 
 <nuon-tabs>
 
-<nuon-tab name="Overview">
+<nuon-tab name="quickstart">
 
 <div style="padding-top:1rem;"></div>
-
-## Quick Start
 
 Once deployed, you can test your httpbin instance with any HTTP client:
 
@@ -37,18 +35,16 @@ curl http://{{ $publicIp }}/delay/3
 
 
 
-### About This App
+## About this App Config
 
-This is a sample Nuon app config demonstrating a simple `terraform_module` component that:
-- Creates an EC2 instance in your AWS account
-- Deploys and runs the httpbin web server
-- Exposes it via a public IP
+This is a sample App Config with a single `terraform_module` component that creates an EC2 instance
+and starts a basic web server. The full source code can be referenced [here](https://github.com/nuonco/example-app-configs/tree/main/httpbin).
 
-**Estimated cost:** ~$2.50/day
+On average, this app costs around ~$2.50 per day to run.
 
 </nuon-tab>
 
-<nuon-tab name="Components">
+<nuon-tab name="health">
 
 <div style="padding-top:1rem;"></div>
 
@@ -78,7 +74,7 @@ This is a sample Nuon app config demonstrating a simple `terraform_module` compo
 
 </nuon-tab>
 
-<nuon-tab name="Debug">
+<nuon-tab name="debug">
 
 <div style="padding-top:1rem;"></div>
 
@@ -96,7 +92,7 @@ This is a sample Nuon app config demonstrating a simple `terraform_module` compo
   </div>
 </div>
 
-### Recent Actions
+## Recent Actions
 
 {{ $workflows := dict }}
 {{ with .nuon.actions }}{{ $workflows = default dict .workflows }}{{ end }}
@@ -141,7 +137,7 @@ This is a sample Nuon app config demonstrating a simple `terraform_module` compo
 
 </nuon-tab>
 
-<nuon-tab name="Infrastructure">
+<nuon-tab name="infrastructure">
 
 <div style="padding-top:1rem;"></div>
 

--- a/httpbin/README.md
+++ b/httpbin/README.md
@@ -1,57 +1,206 @@
 # HTTPBin
 
-{{ if .nuon.install_stack.outputs }}
-AWS | {{ dig "account_id" "000000000000" .nuon.install_stack.outputs }} | {{ .nuon.cloud_account.aws.region }} | {{ dig "vpc_id" "vpc-000000" .nuon.install_stack.outputs }}
-{{ else }}
-AWS | 000000000000 | xx-vvvv-00 | vpc-000000
-{{ end }}
+{{ $accountId := dig "account_id" "000000000000" .nuon.install_stack.outputs }}
+{{ $region := .nuon.cloud_account.aws.region }}
+{{ $vpcId := dig "vpc_id" "vpc-000000" .nuon.install_stack.outputs }}
+{{ $publicIp := dig "public_ip" "" .nuon.components.ec2.outputs }}
 
-A simple service used to test and debug HTTP requests.
-This uses go version which can be found [here](https://github.com/mccutchen/go-httpbin).
+A simple service used to test and debug HTTP requests. Built with the [go-httpbin](https://github.com/mccutchen/go-httpbin) implementation.
 
-Click [here](http://{{.nuon.components.ec2.outputs.public_ip}}) to see your httpbin instance.
+{{ if $publicIp }}Your httpbin instance: [http://{{ $publicIp }}](http://{{ $publicIp }}){{ else }}Deploying...{{ end }}
 
-## Usage
+<nuon-tabs>
+
+<nuon-tab name="Overview">
+
+<div style="padding-top:1rem;"></div>
+
+## Quick Start
+
+Once deployed, you can test your httpbin instance with any HTTP client:
 
 ```bash
-$ curl -X POST -H "Content-Type: application/json" http://{{.nuon.components.ec2.outputs.public_ip}}/post -d '{"foo": "bar"}'
-{
-  "args": {},
-  "headers": {
-    "Accept": [
-      "*/*"
-    ],
-    "Content-Length": [
-      "14"
-    ],
-    "Content-Type": [
-      "application/json"
-    ],
-    "Host": [
-      "54.173.32.179"
-    ],
-    "User-Agent": [
-      "curl/8.7.1"
-    ]
-  },
-  "method": "POST",
-  "origin": "24.242.20.36",
-  "url": "http://54.173.32.179/post",
-  "data": "{\"foo\": \"bar\"}",
-  "files": {},
-  "form": {},
-  "json": {
-    "foo": "bar"
-  }
-}
+# GET request
+curl http://{{ $publicIp }}/get
+
+# POST request with JSON
+curl -X POST -H "Content-Type: application/json" \
+  http://{{ $publicIp }}/post \
+  -d '{"foo": "bar"}'
+
+# Test headers
+curl http://{{ $publicIp }}/headers
+
+# Test delay
+curl http://{{ $publicIp }}/delay/3
 ```
 
-## About this App Config
-
-This is a sample App Config with a single `terraform_module` component that creates an EC2 instance
-and starts a basic web server.
-
-## Cost Estimate
-Running this app in your environment will cost around $2.50/day.
 
 
+### About This App
+
+This is a sample Nuon app config demonstrating a simple `terraform_module` component that:
+- Creates an EC2 instance in your AWS account
+- Deploys and runs the httpbin web server
+- Exposes it via a public IP
+
+**Estimated cost:** ~$2.50/day
+
+</nuon-tab>
+
+<nuon-tab name="Components">
+
+<div style="padding-top:1rem;"></div>
+
+## Deployment Status
+
+{{ $ec2Component := .nuon.components.ec2 }}
+{{ $ec2Status := dig "status" "unknown" $ec2Component }}
+
+<table>
+  <thead>
+    <tr>
+      <th>Component</th>
+      <th>Status</th>
+      <th>Type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>ec2</strong></td>
+      <td><nuon-status status="{{ $ec2Status }}" variant="badge"></nuon-status></td>
+      <td>terraform_module</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
+</nuon-tab>
+
+<nuon-tab name="Debug">
+
+<div style="padding-top:1rem;"></div>
+
+## Runbooks
+
+<div style="display:flex; flex-wrap:wrap; gap:12px; margin-bottom:1.5rem;">
+  <div style="display:flex; flex-direction:column; gap:4px; align-items:flex-start;">
+    <nuon-run-runbook name="deploy_and_verify"></nuon-run-runbook>
+  </div>
+  <div style="display:flex; flex-direction:column; gap:4px; align-items:flex-start;">
+    <nuon-run-runbook name="deploy_verify_and_logs"></nuon-run-runbook>
+  </div>
+  <div style="display:flex; flex-direction:column; gap:4px; align-items:flex-start;">
+    <nuon-run-runbook name="verify_status"></nuon-run-runbook>
+  </div>
+</div>
+
+### Recent Actions
+
+{{ $workflows := dict }}
+{{ with .nuon.actions }}{{ $workflows = default dict .workflows }}{{ end }}
+{{ if $workflows }}
+
+<table>
+  <thead>
+    <tr>
+      <th>Action</th>
+      <th>Status</th>
+      <th>Details</th>
+    </tr>
+  </thead>
+  <tbody>
+  {{ range $name, $workflow := $workflows }}
+    {{ $status := dig "status" "unknown" $workflow }}
+    <tr>
+      <td><code>{{ $name }}</code></td>
+      <td><nuon-status status="{{ $status }}" variant="badge"></nuon-status></td>
+      <td>
+        <nuon-panel heading="Action: {{ $name }}" trigger="View" size="3/4">
+          <table>
+            <thead><tr><th>Field</th><th>Value</th></tr></thead>
+            <tbody>
+              <tr><td>Name</td><td><code>{{ $name }}</code></td></tr>
+              <tr><td>Status</td><td><nuon-status status="{{ $status }}" variant="badge"></nuon-status></td></tr>
+              <tr><td>ID</td><td><code>{{ dig "id" "—" $workflow }}</code></td></tr>
+            </tbody>
+          </table>
+        </nuon-panel>
+      </td>
+    </tr>
+  {{ end }}
+  </tbody>
+</table>
+
+{{ else }}
+
+<nuon-banner theme="info">No actions have run yet.</nuon-banner>
+
+{{ end }}
+
+</nuon-tab>
+
+<nuon-tab name="Infrastructure">
+
+<div style="padding-top:1rem;"></div>
+
+<div style="display:flex;gap:1.5rem;align-items:flex-start;">
+  <div style="flex:1;min-width:0;">
+
+<div style="display:flex;align-items:baseline;gap:0.75rem;"><h3 style="margin:0;">AWS Stack</h3></div>
+
+{{ $stackStatus := dig "status" "" .nuon.install_stack }}
+{{ $stackOutputs := default dict .nuon.install_stack.outputs }}
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Value</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Status</td><td>{{ if $stackStatus }}<nuon-status status="{{ $stackStatus }}" variant="badge"></nuon-status>{{ else }}—{{ end }}</td></tr>
+    <tr><td>Account</td><td><code>{{ $accountId }}</code></td></tr>
+    <tr><td>Region</td><td><code>{{ $region }}</code></td></tr>
+    <tr><td>VPC</td><td><code>{{ $vpcId }}</code></td></tr>
+  </tbody>
+</table>
+
+  </div>
+  <div style="flex:1;min-width:0;">
+
+<div style="display:flex;align-items:baseline;gap:0.75rem;"><h3 style="margin:0;">EC2 Instance</h3></div>
+
+{{ $ec2Status := dig "status" "unknown" .nuon.components.ec2 }}
+
+<table style="width:100%;">
+  <thead>
+    <tr><th style="width:30%;">Field</th><th style="width:70%;">Value</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Status</td><td><nuon-status status="{{ $ec2Status }}" variant="badge"></nuon-status></td></tr>
+    <tr><td>Public IP</td><td>{{ if $publicIp }}<code>{{ $publicIp }}</code>{{ else }}—{{ end }}</td></tr>
+    <tr><td>Name</td><td><code>ec2</code></td></tr>
+    <tr><td>Type</td><td>terraform_module</td></tr>
+  </tbody>
+</table>
+
+  </div>
+</div>
+
+<div style="margin-top:1.5rem;">
+
+<div style="display:flex;align-items:baseline;gap:0.75rem;"><h3 style="margin:0;">Install Information</h3></div>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Value</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Install ID</td><td><code>{{ .nuon.install.id }}</code></td></tr>
+    <tr><td>Install Name</td><td>{{ dig "name" "—" .nuon.install }}</td></tr>
+  </tbody>
+</table>
+
+</nuon-tab>
+
+</nuon-tabs>


### PR DESCRIPTION
Enhanced the httpbin README with interactive tabs, live component status, and improved organization.

New tabbed interface:
- quickstart - Quick start guide with curl examples and app info
- health - EC2 component deployment status
- debug - Runbook buttons for manual operations
- infrastructure - Live AWS stack and EC2 instance details, plus install information

Interactive features:
- Added runbook buttons (`deploy_and_verify`, `deploy_verify_and_logs`, `verify_status`) with run functionality
- Live component status badges showing EC2 deployment state
- Side-by-side AWS Stack and EC2 Instance info cards
- Recent actions history table with expandable details

Improvements:
- Added link to source code on GitHub
- Cleaner cost estimate messaging
- Removed redundant component details panel
- All tables use consistent Field/Value format
