### PR TITLE
feat: add eks-arm app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ crash.*.log
 !aca-simple/sandbox.tfvars
 !aws-lambda/sandbox.tfvars
 !byo-vpc/sandbox.tfvars
+!eks-arm/sandbox.tfvars
 !eks-multi-env/sandbox.tfvars
 !eks-simple-kustomize/sandbox.tfvars
 !n8n/sandbox.tfvars

--- a/eks-arm/.meta.yaml
+++ b/eks-arm/.meta.yaml
@@ -1,0 +1,15 @@
+cloud: aws
+category:
+  - architecture
+infra: eks
+stack:
+  - terraform
+  - kubernetes
+features: []
+tags:
+  - eks
+  - kubernetes
+  - arm64
+  - graviton
+links:
+  docs: https://docs.nuon.co/get-started/create-your-first-app

--- a/eks-arm/README.md
+++ b/eks-arm/README.md
@@ -1,0 +1,30 @@
+# EKS ARM
+
+Runs httpbin on EKS using an arm64 image on Graviton instances.
+
+## URL
+
+{{ if and .nuon.sandbox.populated .nuon.sandbox.outputs }}
+
+| Service | URL                                                                                                                                |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| httpbin | [httpbin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}](http://httpbin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}) |
+
+{{ else }} Results will be visible after the sandbox is deployed. {{ end }}
+
+## The ARM bits
+
+`sandbox.tfvars` — both settings are required and must agree. Setting the
+instance type alone fails: the node group defaults to an x86 AMI, and AWS
+rejects a node group whose instance architecture doesn't match its AMI
+type.
+
+```hcl
+ami_type              = "AL2023_ARM_64_STANDARD"
+default_instance_type = "t4g.medium"
+```
+
+## Image
+
+`ghcr.io/mccutchen/go-httpbin:2.18.2` — multi-arch, publishes
+`linux/arm64`.

--- a/eks-arm/README.md
+++ b/eks-arm/README.md
@@ -8,7 +8,7 @@ Runs httpbin on EKS using an arm64 image on Graviton instances.
 
 | Service | URL                                                                                                                                |
 | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| httpbin | [httpbin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}](http://httpbin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}) |
+| httpbin | [{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}](http://{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}) |
 
 {{ else }} Results will be visible after the sandbox is deployed. {{ end }}
 

--- a/eks-arm/README.md
+++ b/eks-arm/README.md
@@ -14,15 +14,18 @@ Runs httpbin on EKS using an arm64 image on Graviton instances.
 
 ## The ARM bits
 
-`sandbox.tfvars` — both settings are required and must agree. Setting the
+`sandbox.toml` — both settings are required and must agree. Setting the
 instance type alone fails: the node group defaults to an x86 AMI, and AWS
 rejects a node group whose instance architecture doesn't match its AMI
 type.
 
-```hcl
+```toml
+[vars]
 ami_type              = "AL2023_ARM_64_STANDARD"
 default_instance_type = "t4g.medium"
 ```
+
+Node group sizing is left at the sandbox defaults on purpose.
 
 ## Image
 

--- a/eks-arm/components/1-httpbin/httpbin.toml
+++ b/eks-arm/components/1-httpbin/httpbin.toml
@@ -1,5 +1,4 @@
-name             = "httpbin"
-type             = "kubernetes_manifest"
-namespace        = "httpbin"
-manifest         = "./1-httpbin/manifest.yaml"
-max_auto_retries = 5
+name         = "httpbin"
+type         = "kubernetes_manifest"
+namespace    = "httpbin"
+manifest     = "./1-httpbin/manifest.yaml"

--- a/eks-arm/components/1-httpbin/httpbin.toml
+++ b/eks-arm/components/1-httpbin/httpbin.toml
@@ -1,0 +1,5 @@
+name             = "httpbin"
+type             = "kubernetes_manifest"
+namespace        = "httpbin"
+manifest         = "./1-httpbin/manifest.yaml"
+max_auto_retries = 5

--- a/eks-arm/components/1-httpbin/manifest.yaml
+++ b/eks-arm/components/1-httpbin/manifest.yaml
@@ -4,8 +4,6 @@ kind: Deployment
 metadata:
   name: httpbin
   namespace: httpbin
-  labels:
-    app.kubernetes.io/name: httpbin
 spec:
   replicas: 1
   selector:
@@ -23,25 +21,10 @@ spec:
           image: ghcr.io/mccutchen/go-httpbin:2.18.2
           ports:
             - containerPort: 8080
-          resources:
-            limits:
-              cpu: "250m"
-              memory: "128Mi"
-            requests:
-              cpu: "100m"
-              memory: "64Mi"
-          livenessProbe:
-            httpGet:
-              path: /status/200
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 10
           readinessProbe:
             httpGet:
               path: /status/200
               port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
 ---
 apiVersion: v1
 kind: Service
@@ -52,8 +35,6 @@ spec:
   ports:
     - name: http
       port: 80
-      protocol: TCP
       targetPort: 8080
   selector:
     app.kubernetes.io/name: httpbin
-  type: ClusterIP

--- a/eks-arm/components/1-httpbin/manifest.yaml
+++ b/eks-arm/components/1-httpbin/manifest.yaml
@@ -57,22 +57,3 @@ spec:
   selector:
     app.kubernetes.io/name: httpbin
   type: ClusterIP
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: httpbin
-  namespace: httpbin
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: httpbin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}
-      http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: httpbin
-                port:
-                  name: http

--- a/eks-arm/components/1-httpbin/manifest.yaml
+++ b/eks-arm/components/1-httpbin/manifest.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: httpbin
+  labels:
+    app.kubernetes.io/name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: httpbin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: httpbin
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      containers:
+        - name: httpbin
+          image: ghcr.io/mccutchen/go-httpbin:2.18.2
+          ports:
+            - containerPort: 8080
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "128Mi"
+            requests:
+              cpu: "100m"
+              memory: "64Mi"
+          livenessProbe:
+            httpGet:
+              path: /status/200
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /status/200
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: httpbin
+spec:
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: httpbin
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: httpbin
+  namespace: httpbin
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: httpbin.{{ .nuon.sandbox.outputs.nuon_dns.public_domain.name }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: httpbin
+                port:
+                  name: http

--- a/eks-arm/components/2-alb/alb.toml
+++ b/eks-arm/components/2-alb/alb.toml
@@ -1,0 +1,6 @@
+name             = "alb"
+type             = "kubernetes_manifest"
+namespace        = "httpbin"
+dependencies     = ["httpbin"]
+manifest         = "./2-alb/manifest.yaml"
+max_auto_retries = 5

--- a/eks-arm/components/2-alb/alb.toml
+++ b/eks-arm/components/2-alb/alb.toml
@@ -1,6 +1,5 @@
-name             = "alb"
-type             = "kubernetes_manifest"
-namespace        = "httpbin"
-dependencies     = ["httpbin"]
-manifest         = "./2-alb/manifest.yaml"
-max_auto_retries = 5
+name         = "alb"
+type         = "kubernetes_manifest"
+namespace    = "httpbin"
+dependencies = ["httpbin"]
+manifest     = "./2-alb/manifest.yaml"

--- a/eks-arm/components/2-alb/manifest.yaml
+++ b/eks-arm/components/2-alb/manifest.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alb
+  namespace: httpbin
+  labels:
+    app.nuon.co/install: "{{ .nuon.install.id }}"
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    alb.ingress.kubernetes.io/healthcheck-path: "/status/200"
+    external-dns.alpha.kubernetes.io/hostname: "{{ .nuon.install.sandbox.outputs.nuon_dns.public_domain.name }}"
+spec:
+  ingressClassName: alb
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: httpbin
+                port:
+                  name: http

--- a/eks-arm/components/2-alb/manifest.yaml
+++ b/eks-arm/components/2-alb/manifest.yaml
@@ -4,8 +4,6 @@ kind: Ingress
 metadata:
   name: alb
   namespace: httpbin
-  labels:
-    app.nuon.co/install: "{{ .nuon.install.id }}"
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip

--- a/eks-arm/metadata.toml
+++ b/eks-arm/metadata.toml
@@ -1,0 +1,11 @@
+version = "v2"
+
+display_name = "EKS ARM"
+description  = "httpbin on an all-Graviton EKS node group"
+readme       = "./README.md"
+
+[onboarding]
+enabled        = true
+category       = "architecture"
+difficulty     = "simple"
+cloud_provider = "aws"

--- a/eks-arm/permissions/deprovision.toml
+++ b/eks-arm/permissions/deprovision.toml
@@ -1,0 +1,8 @@
+type                 = "deprovision"
+name                 = "{{.nuon.install.id}}-deprovision"
+description          = "deprovision sandbox and components. you must still delete the cf stack to delete the runner, ec2 vm, and vpc."
+display_name         = "deprovision role"
+permissions_boundary = "./deprovision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/eks-arm/permissions/deprovision_boundary.json
+++ b/eks-arm/permissions/deprovision_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/eks-arm/permissions/maintenance.toml
+++ b/eks-arm/permissions/maintenance.toml
@@ -1,0 +1,8 @@
+type                 = "maintenance"
+name                 = "{{.nuon.install.id}}-maintenance"
+description          = "operate and remediate the app's components and use actions."
+display_name         = "maintenance role"
+permissions_boundary = "./maintenance_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/eks-arm/permissions/maintenance_boundary.json
+++ b/eks-arm/permissions/maintenance_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/eks-arm/permissions/provision.toml
+++ b/eks-arm/permissions/provision.toml
@@ -1,0 +1,8 @@
+type                 = "provision"
+name                 = "{{.nuon.install.id}}-provision"
+description          = "provision the sandbox and components; trigger actions."
+display_name         = "provision role"
+permissions_boundary = "./provision_boundary.json"
+
+[[policies]]
+managed_policy_name = "AdministratorAccess"

--- a/eks-arm/permissions/provision_boundary.json
+++ b/eks-arm/permissions/provision_boundary.json
@@ -1,0 +1,10 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "*",
+      "Resource": "*"
+    }
+  ]
+}

--- a/eks-arm/runner.toml
+++ b/eks-arm/runner.toml
@@ -1,0 +1,3 @@
+runner_type     = "aws"
+helm_driver     = "configmap"
+init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/tags/aws-v0.1.4/scripts/aws/init-mng.sh"

--- a/eks-arm/runner.toml
+++ b/eks-arm/runner.toml
@@ -1,3 +1,2 @@
 runner_type     = "aws"
-helm_driver     = "configmap"
 init_script_url = "https://raw.githubusercontent.com/nuonco/runner/refs/tags/aws-v0.1.4/scripts/aws/init-mng.sh"

--- a/eks-arm/sandbox.tfvars
+++ b/eks-arm/sandbox.tfvars
@@ -1,0 +1,1 @@
+additional_namespaces = ["httpbin"]

--- a/eks-arm/sandbox.toml
+++ b/eks-arm/sandbox.toml
@@ -1,10 +1,9 @@
 terraform_version = "1.11.3"
 
-# NOTE: pinned to the ami_type branch until that change lands on main.
 [public_repo]
 directory = "."
 repo      = "nuonco/aws-eks-sandbox"
-branch    = "ey/arm-ami-type"
+branch    = "main"
 
 [vars]
 cluster_name    = "n-{{.nuon.install.id}}"

--- a/eks-arm/sandbox.toml
+++ b/eks-arm/sandbox.toml
@@ -10,6 +10,9 @@ branch    = "ey/arm-ami-type"
 cluster_name    = "n-{{.nuon.install.id}}"
 cluster_version = "1.35"
 
+ami_type              = "AL2023_ARM_64_STANDARD"
+default_instance_type = "t4g.medium"
+
 enable_nuon_dns                = "true"
 public_root_domain             = "{{ .nuon.install.id }}.nuon.run"
 internal_root_domain           = "internal.{{ .nuon.install.id }}.nuon.run"

--- a/eks-arm/sandbox.toml
+++ b/eks-arm/sandbox.toml
@@ -1,0 +1,19 @@
+terraform_version = "1.11.3"
+
+# NOTE: pinned to the ami_type branch until that change lands on main.
+[public_repo]
+directory = "."
+repo      = "nuonco/aws-eks-sandbox"
+branch    = "ey/arm-ami-type"
+
+[vars]
+cluster_name    = "n-{{.nuon.install.id}}"
+cluster_version = "1.35"
+
+enable_nuon_dns                = "true"
+public_root_domain             = "{{ .nuon.install.id }}.nuon.run"
+internal_root_domain           = "internal.{{ .nuon.install.id }}.nuon.run"
+cluster_endpoint_public_access = "true"
+
+[[var_file]]
+contents = "./sandbox.tfvars"

--- a/eks-arm/stack.toml
+++ b/eks-arm/stack.toml
@@ -1,0 +1,6 @@
+type        = "aws-cloudformation"
+name        = "nuon-eks-arm-{{.nuon.install.id}}"
+description = "QuickLink to install runner: Install {{.nuon.install.id}}"
+
+vpc_nested_template_url    = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/vpc/eks/default/stack.yaml"
+runner_nested_template_url = "https://nuon-artifacts.s3.us-west-2.amazonaws.com/aws-cloudformation-templates/v0.4.0/runner/asg/stack.yaml"


### PR DESCRIPTION
Adding a an example app which exercises ARM EKS instance types and AMI.

Relevant lines from `sandbox.toml`:

```
ami_type              = "AL2023_ARM_64_STANDARD"
default_instance_type = "t4g.medium"
```
